### PR TITLE
Deepen Cunhaobot domain modules (PRD #76)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,20 @@ The project uses the specialized Litestar HTMX plugin for web interactivity.
 *   To run the project locally, use the `./dev.sh` script. This requires Docker for the Datastore emulator.
 *   Ensure a `.env` file exists (based on `.env.example`) with the necessary environment variables.
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `jenarvaezg/cunhaobot` using `gh`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default five-label triage vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repo: read root `CONTEXT.md` and relevant ADRs under `docs/adr/` when present. See `docs/agents/domain.md`.
+
 ## CI/CD & Deployment
 
 ### Automated Deployment

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,158 @@
+# Cunhaobot
+
+Cunhaobot captura el lenguaje del cuñado de barra español: saludos cortos, sentencias opinadas y rituales comunitarios alrededor de esa persona.
+
+## Lenguaje
+
+**Apelativo**:
+Palabra o expresión corta que completa un saludo cuñadil.
+_Evitar_: frase corta, palabra poderosa
+
+**Frase cuñadil**:
+Sentencia completa con tono de cuñado, lista para enviarse tal cual.
+_Evitar_: frase larga, dicho
+
+**Pieza cuñadil**:
+Unidad de contenido aprobada que Cunhaobot puede usar o mostrar.
+_Evitar_: contenido, item, recurso, frase
+
+**Cuenta de plataforma**:
+Identidad de una persona dentro de una plataforma concreta como Telegram o Slack.
+_Evitar_: cuenta, usuario de plataforma
+
+**Perfil**:
+Identidad unificada donde viven la reputación, autoría e historial comunitario de un participante.
+_Evitar_: usuario, cuenta principal
+
+**Chat**:
+Espacio de conversación donde Cunhaobot participa, sea privado, grupo, canal o equivalente de plataforma.
+_Evitar_: grupo, canal, conversación
+
+**Suscripción Premium**:
+Acceso de pago que habilita capacidades avanzadas de Cunhaobot en un **Chat**.
+_Evitar_: premium de usuario, plan, membresía
+
+**Propuesta**:
+Candidatura de contenido cuñadil pendiente de evaluación por el **Consejo**.
+_Evitar_: aportación, sugerencia, frase propuesta
+
+**Consejo**:
+Grupo de personas con permiso para evaluar **Propuestas**.
+_Evitar_: moderadores, curadores, admins
+
+**Logro**:
+Reconocimiento visible que un **Perfil** gana por alcanzar un hito cuñadil.
+_Evitar_: badge, medalla, insignia
+
+**Puntos de reputación**:
+Saldo acumulado de prestigio cuñadil de un **Perfil**.
+_Evitar_: puntos, score
+
+**Juego**:
+Experiencia lúdica dentro de Cunhaobot que puede jugarse muchas veces.
+_Evitar_: mini-juego, game
+
+**Partida**:
+Intento individual de **Juego** realizado por un **Perfil**.
+_Evitar_: sesión, run, intento
+
+**Puntuación de partida**:
+Resultado obtenido por un **Perfil** en una partida concreta.
+_Evitar_: score, puntos de juego
+
+**Clasificación de reputación**:
+Lista ordenada de **Perfiles** por **Puntos de reputación**.
+_Evitar_: ranking, leaderboard, top
+
+**Clasificación de juego**:
+Lista ordenada de **Perfiles** por su mejor **Puntuación de partida**.
+_Evitar_: ranking, leaderboard, top
+
+**Regalo**:
+Detalle digital que un **Perfil** envía a otro **Perfil** dentro de un **Chat**.
+_Evitar_: gift, item, compra
+
+**Póster**:
+Imagen generada bajo demanda a partir de texto cuñadil para un **Perfil** en un **Chat**.
+_Evitar_: imagen IA, poster request, generación
+
+## Relaciones
+
+- Un **Apelativo** puede presentarse como saludo.
+- Una **Frase cuñadil** se sostiene sola, sin marco de saludo.
+- Un **Apelativo** es un tipo de **Pieza cuñadil**.
+- Una **Frase cuñadil** es un tipo de **Pieza cuñadil**.
+- Un **Perfil** puede agrupar una o más **Cuentas de plataforma**.
+- Una **Cuenta de plataforma** pertenece exactamente a un **Perfil**.
+- Un **Chat** reúne interacciones entre Cunhaobot y una o más **Cuentas de plataforma**.
+- Un **Chat** puede tener cero o una **Suscripción Premium** activa.
+- Una **Suscripción Premium** pertenece exactamente a un **Chat**.
+- Una **Propuesta** es evaluada por el **Consejo**.
+- El **Consejo** puede aprobar o rechazar una **Propuesta**.
+- Una **Propuesta** aprobada puede convertirse en una **Pieza cuñadil**.
+- Un **Perfil** puede ganar cero o más **Logros**.
+- Un **Perfil** acumula **Puntos de reputación**.
+- Un **Juego** puede tener cero o más **Partidas**.
+- Una **Partida** pertenece exactamente a un **Juego**.
+- Una **Partida** pertenece exactamente a un **Perfil**.
+- Un **Perfil** puede obtener cero o más **Puntuaciones de partida**.
+- Una **Partida** produce exactamente una **Puntuación de partida**.
+- Una **Puntuación de partida** puede generar **Puntos de reputación**.
+- Una **Clasificación de reputación** ordena **Perfiles** por **Puntos de reputación**.
+- Una **Clasificación de juego** ordena **Perfiles** por **Puntuación de partida**.
+- Un **Regalo** tiene exactamente un **Perfil** remitente.
+- Un **Regalo** tiene exactamente un **Perfil** destinatario.
+- Un **Regalo** ocurre en exactamente un **Chat**.
+- Un **Póster** pertenece exactamente a un **Perfil**.
+- Un **Póster** se solicita desde exactamente un **Chat**.
+
+## Ejemplo de diálogo
+
+> **Desarrollo:** "Si alguien propone `maquina`, ¿eso es una **Frase cuñadil**?"
+> **Experto de dominio:** "No, `maquina` es un **Apelativo**; `yo de esto piloto` es una **Frase cuñadil**."
+>
+> **Desarrollo:** "Cuando alguien vincula Telegram y Slack, ¿conservamos dos **Perfiles**?"
+> **Experto de dominio:** "No, son dos **Cuentas de plataforma** bajo un único **Perfil**."
+>
+> **Desarrollo:** "Si Cunhaobot habla en un grupo de Telegram, ¿eso es un grupo o un canal?"
+> **Experto de dominio:** "Para el dominio es un **Chat**; la forma concreta depende de la plataforma."
+>
+> **Desarrollo:** "Si activo Premium en un grupo, ¿mi **Perfil** es Premium en todos lados?"
+> **Experto de dominio:** "No, la **Suscripción Premium** pertenece a ese **Chat**."
+>
+> **Desarrollo:** "Si alguien quiere añadir una nueva frase al repertorio, ¿la guardamos directamente?"
+> **Experto de dominio:** "No, primero entra como **Propuesta** y el **Consejo** decide si se aprueba."
+>
+> **Desarrollo:** "Si mañana añadimos imágenes o audios aprobados, ¿también son frases?"
+> **Experto de dominio:** "No, son otros tipos de **Pieza cuñadil**."
+>
+> **Desarrollo:** "Si alguien juega mucho o propone buen contenido, ¿gana medallas?"
+> **Experto de dominio:** "En el dominio gana **Logros**; medalla es solo una forma coloquial de decirlo."
+>
+> **Desarrollo:** "Si alguien hace 550 en el juego, ¿tiene 550 **Puntos de reputación**?"
+> **Experto de dominio:** "No, 550 es una **Puntuación de partida**; puede convertirse en algunos **Puntos de reputación**."
+>
+> **Desarrollo:** "Si alguien juega tres veces, ¿eso son tres juegos?"
+> **Experto de dominio:** "No, es un **Juego** con tres **Partidas**."
+>
+> **Desarrollo:** "¿El ranking de la web y el top jugones son la misma lista?"
+> **Experto de dominio:** "No, una es la **Clasificación de reputación** y la otra es la **Clasificación de juego**."
+>
+> **Desarrollo:** "Si alguien manda un palillo digital a otro, ¿eso es una **Pieza cuñadil**?"
+> **Experto de dominio:** "No, es un **Regalo** entre **Perfiles** dentro de un **Chat**."
+>
+> **Desarrollo:** "Si alguien genera una imagen con una frase, ¿eso entra al repertorio?"
+> **Experto de dominio:** "No, es un **Póster** generado bajo demanda."
+
+## Ambigüedades resueltas
+
+- "frase" se usó para significar tanto **Apelativo** como **Frase cuñadil**; resuelto: usar el término preciso siempre que la distinción importe.
+- "contenido" e "item" se usaron como cajón de sastre; resuelto: usar **Pieza cuñadil** para la unidad aprobada del repertorio.
+- "usuario" y "cuenta" se usaron tanto para **Cuenta de plataforma** como para **Perfil**; resuelto: usar **Perfil** para la identidad unificada y **Cuenta de plataforma** para la identidad específica de plataforma.
+- "moderadores", "curadores" y "admins" se usaron para quienes evalúan contenido; resuelto: en el dominio son el **Consejo**.
+- "badge", "medalla" e "insignia" se usaron para los reconocimientos del perfil; resuelto: usar **Logro**.
+- "puntos" se usó tanto para reputación como para resultados de juego; resuelto: usar **Puntos de reputación** y **Puntuación de partida**.
+- "juego" se usó para la experiencia y para cada intento; resuelto: usar **Juego** para la experiencia y **Partida** para cada intento individual.
+- "ranking", "leaderboard" y "top" se usaron para listas ordenadas distintas; resuelto: usar **Clasificación de reputación** o **Clasificación de juego** según el criterio.
+- "gift", "item" y "compra" se usaron para detalles digitales entre participantes; resuelto: usar **Regalo**.
+- "imagen IA", "poster request" y "generación" se usaron para imágenes bajo demanda; resuelto: usar **Póster**.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Layout
+
+This is a single-context repo.
+
+- Read `CONTEXT.md` at the repo root before domain-sensitive work.
+- Read `docs/domain-code-map.md` when translating domain terms into code changes.
+- Read relevant ADRs under `docs/adr/` if that directory exists.
+- If optional docs do not exist, proceed silently. Do not suggest creating them upfront.
+
+The producer skill (`/grill-with-docs`) creates missing context or ADR files lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```text
+/
+├── CONTEXT.md
+├── docs/domain-code-map.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── 0002-example-decision.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept in an issue title, refactor proposal, hypothesis, or test name, use the term as defined in `CONTEXT.md`. Do not drift to synonyms the glossary explicitly avoids.
+
+If the concept you need is not in the glossary yet, reconsider whether you are inventing language the project does not use. If it is a real gap, note it for `/grill-with-docs`.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `jenarvaezg/cunhaobot`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/domain-code-map.md
+++ b/docs/domain-code-map.md
@@ -1,0 +1,32 @@
+# Domain To Code Map
+
+This document maps Spanish domain language from `CONTEXT.md` to current English code identifiers.
+
+The glossary is authoritative for product language. Code identifiers remain English. Some code names are historical and do not yet match the domain precisely.
+
+| Domain term | Current code identifiers | Notes |
+| --- | --- | --- |
+| **Apelativo** | `Phrase`, `PhraseRepository`, `phrase_repo`, short inline mode | Historical name: the project originally only stored short greeting words and called them phrases. |
+| **Frase cuñadil** | `LongPhrase`, `LongPhraseRepository`, `long_phrase_repo`, long inline mode | Historical name: added later as "long phrase" to distinguish it from `Phrase`. |
+| **Pieza cuñadil** | Currently `Phrase` and `LongPhrase`; future approved content models | Umbrella domain term for approved repertory content. |
+| **Cuenta de plataforma** | `User` records with `platform`, platform-specific IDs | A Telegram or Slack identity before conceptual unification into a profile. |
+| **Perfil** | The canonical `User` record reached after account linking; `linked_to` marks absorbed platform accounts | The domain term is "Perfil", but code should keep English names. |
+| **Chat** | `Chat`, `ChatRepository`, `chat_repo` | The conversation space where the bot participates; currently also carries chat-level state. |
+| **Suscripción Premium** | `Chat.premium_until`, `/premium`, `ActionType.SUBSCRIPTION` | Premium is currently chat-scoped, not profile-scoped. |
+| **Propuesta** | `Proposal`, `LongProposal`, `ProposalService`, `proposal_repo`, `long_proposal_repo` | Current code has separate proposal classes for historical apelativo/frase split. |
+| **Consejo** | `config.mod_chat_id`, Telegram chat administrators, `get_curators`, approve/reject callbacks | Domain term for the people who evaluate proposals. |
+| **Logro** | `Badge`, `BadgeProgress`, `BADGES`, `User.badges`, `BadgeService` | Code uses badge terminology; domain language should say "Logro". |
+| **Puntos de reputación** | `User.points`, `add_points` | General prestige balance for a profile. |
+| **Juego** | `GameController`, `GameService`, `/game`, `palillo_cunhao`, `/jugar` | Current production game is Palillo, but the domain term stays generic. |
+| **Partida** | score submission flow, `GameService.set_score` | Current code records aggregate game stats rather than a separate persisted play record. |
+| **Puntuación de partida** | `score`, `User.game_high_score`, `GameService.set_score` | Game result; code may convert it into reputation points. |
+| **Clasificación de reputación** | `/ranking`, `WebController.ranking`, `ranking.html` | Ordered by `User.points`. |
+| **Clasificación de juego** | `/game/ranking`, `/top_jugones`, `game_ranking.html`, `handle_top_jugones` | Ordered by `User.game_high_score`. |
+| **Regalo** | `Gift`, `GiftType`, `GiftRepository`, `/regalar`, gift payment payloads | Social digital gift between profiles in a chat. |
+| **Póster** | `PosterRequest`, `PosterRequestRepository`, `/poster`, `AIService.generate_image` | On-demand generated image, not approved repertory content. |
+
+## Naming Rule
+
+- Domain documentation uses Spanish product terms from `CONTEXT.md`.
+- Python code, tests, modules, functions, classes, and variables use English identifiers.
+- When changing code near a historical name, prefer clearer English names for new symbols while preserving compatibility with existing persisted data.

--- a/docs/domain-code-map.md
+++ b/docs/domain-code-map.md
@@ -30,3 +30,18 @@ The glossary is authoritative for product language. Code identifiers remain Engl
 - Domain documentation uses Spanish product terms from `CONTEXT.md`.
 - Python code, tests, modules, functions, classes, and variables use English identifiers.
 - When changing code near a historical name, prefer clearer English names for new symbols while preserving compatibility with existing persisted data.
+
+## Deepened Module Interfaces
+
+These modules hide historical implementation details behind a small, stable interface. Callers cross the interface instead of reassembling behavior.
+
+| Domain concern | Deeper interface | What it hides |
+| --- | --- | --- |
+| **Partida** submission | `GameService.submit_score()` | Token validation, high-score/streak update, single Puntuación → Puntos de reputación conversion. |
+| **Pieza cuñadil** intake | `ProposalService.submit()` → `IntakeResult` | Empty/duplicate decision across approved Pieza cuñadil and pending/rejected Propuesta; Apelativo vs Frase cuñadil split (derived from proposal type). |
+| Paid fulfillment | `services.payment.parse_payment_payload()` → `GiftPayment` / `SubscriptionPayment` / `PosterPayment` | `startswith`/`split` parsing; routing to Regalo, Póster or Suscripción Premium. |
+| **Perfil** linking | `UserService.complete_link()` / `_migrate_authorship()` | Token lifecycle, canonical resolution, absorbed-account aliasing, one-seam authorship migration. |
+| **Logro** engine | `BadgeService.check_badges()` → `list[Badge]` | Milestone rules; platform notification stays in Telegram/Slack adapters. |
+| **Perfil** aggregation | `ProfileService.get_profile_summary()` → `ProfileSummary` | One coherent summary (Puntos, Logros, Pieza cuñadil, Regalos, Pósters) for web and bot. |
+| **Chat** interaction | `ChatInteractionService` (`answer`, `decide_reaction`, `record_reaction_received`) | Shared AI response, reaction decision and Uso logging across Telegram and Slack adapters. |
+| Composition | `core.container.Container` | Single composition root; `core.di` only exposes its singletons to Litestar. |

--- a/src/api/game.py
+++ b/src/api/game.py
@@ -1,51 +1,47 @@
 import logging
-import hashlib
-import hmac
-import time
 import zlib
-from typing import Annotated
+from collections.abc import Mapping
+from typing import Annotated, cast
 from litestar import Controller, Request, get, post
 from litestar.response import Template
 from litestar.params import Dependency
 from litestar.exceptions import HTTPException
 
-from services.game_service import GameService
+from services.game_service import (
+    GamePlayerProfile,
+    GameService,
+    InvalidGameSessionError,
+)
 from services.user_service import UserService
 from services.tts_service import TTSService
 from services.phrase_service import PhraseService
-from core.config import config
 from utils.ui import apelativo
 from models.phrase import Phrase
 
 logger = logging.getLogger(__name__)
 
 
+def _player_profile_from_session(session_user: object) -> GamePlayerProfile | None:
+    if not isinstance(session_user, Mapping):
+        return None
+
+    session_data = cast(Mapping[str, object], session_user)
+    user_id = session_data.get("id")
+    if not isinstance(user_id, str | int):
+        return None
+
+    first_name = session_data.get("first_name")
+    username = session_data.get("username")
+    name = first_name if isinstance(first_name, str) and first_name else "Usuario Web"
+    return GamePlayerProfile(
+        user_id=user_id,
+        name=name,
+        username=username if isinstance(username, str) else None,
+    )
+
+
 class GameController(Controller):
     path = "/game"
-
-    def _generate_game_token(self, user_id: str | int) -> str:
-        timestamp = int(time.time())
-        payload = f"{user_id}:{timestamp}"
-        signature = hmac.new(
-            config.session_secret.encode(), payload.encode(), hashlib.sha256
-        ).hexdigest()
-        return f"{signature}:{timestamp}"
-
-    def _verify_game_token(self, user_id: str | int, token: str) -> bool:
-        try:
-            signature, timestamp_str = token.split(":")
-            timestamp = int(timestamp_str)
-            # Token valid for 2 hours
-            if time.time() - timestamp > 7200:
-                return False
-
-            payload = f"{user_id}:{timestamp}"
-            expected_signature = hmac.new(
-                config.session_secret.encode(), payload.encode(), hashlib.sha256
-            ).hexdigest()
-            return hmac.compare_digest(signature, expected_signature)
-        except (ValueError, AttributeError):
-            return False
 
     @get("/launch")
     async def launch_game(
@@ -54,6 +50,7 @@ class GameController(Controller):
         tts_service: Annotated[TTSService, Dependency()],
         phrase_service: Annotated[PhraseService, Dependency()],
         user_service: Annotated[UserService, Dependency()],
+        game_service: Annotated[GameService, Dependency()],
     ) -> Template:
         """Endpoint called by Telegram to launch the game."""
         # Validate telegram web app init data if possible, or use simplified launch
@@ -131,7 +128,7 @@ class GameController(Controller):
                 "chat_id": chat_id,
                 "message_id": message_id,
                 "game_short_name": "palillo_cunhao",
-                "game_token": self._generate_game_token(user_id),
+                "game_token": game_service.generate_game_token(user_id),
                 "is_web": False,
                 "greeting_audio_url": greeting_audio_url,
                 "game_over_audio_url": game_over_audio_url,
@@ -169,53 +166,36 @@ class GameController(Controller):
         self,
         request: Request,
         game_service: Annotated[GameService, Dependency()],
-        user_service: Annotated[UserService, Dependency()],
     ) -> dict[str, str | bool]:
         """Submit score from the game."""
         data = await request.json()
         user_id = data.get("user_id")
-        score = data.get("score", 0)
+        score = int(data.get("score", 0))
         inline_message_id = data.get("inline_message_id") or None
         chat_id = data.get("chat_id") or None
         message_id = data.get("message_id") or None
         token = data.get("token")
 
-        if not self._verify_game_token(user_id, token):
+        if not isinstance(user_id, str | int) or not isinstance(token, str):
             logger.warning(f"Invalid game token for user {user_id}")
             raise HTTPException(status_code=403, detail="Invalid game session")
 
-        # Save score and update highscore in Telegram
-        success = await game_service.set_score(
-            user_id=user_id,
-            score=score,
-            inline_message_id=inline_message_id,
-            chat_id=chat_id,
-            message_id=message_id,
-        )
-
-        # If it failed, maybe user is missing from DB (e.g. web play without prior bot interaction)
-        if not success and user_id != "guest":
-            user_session = request.session.get("user")
-            if user_session and str(user_session.get("id")) == str(user_id):
-                # Create skeleton user from session
-                await user_service.update_user_data(
-                    user_id=user_id,
-                    name=user_session.get("first_name", "Usuario Web"),
-                    username=user_session.get("username"),
-                )
-                # Retry
-                success = await game_service.set_score(
-                    user_id=user_id,
-                    score=score,
-                    inline_message_id=inline_message_id,
-                    chat_id=chat_id,
-                    message_id=message_id,
-                )
-
-        # Award points to user based on performance (1 point per 100 points in game)
-        if success and user_id != "guest":
-            points = int(score / 100)
-            if points > 0:
-                await user_service.add_points(user_id, points)
+        try:
+            success = await game_service.submit_score(
+                user_id=user_id,
+                score=score,
+                token=token,
+                inline_message_id=inline_message_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                player_profile=_player_profile_from_session(
+                    request.session.get("user")
+                ),
+            )
+        except InvalidGameSessionError:
+            logger.warning(f"Invalid game token for user {user_id}")
+            raise HTTPException(
+                status_code=403, detail="Invalid game session"
+            ) from None
 
         return {"status": "ok", "success": success}

--- a/src/api/game_test.py
+++ b/src/api/game_test.py
@@ -15,17 +15,25 @@ def client():
 
 
 def test_game_launch(client):
-    response = client.get(
-        "/game/launch", params={"user_id": "123", "inline_message_id": "abc"}
-    )
+    with patch(
+        "services.game_service.GameService.generate_game_token",
+        return_value="service-token",
+        create=True,
+    ) as mock_generate_token:
+        response = client.get(
+            "/game/launch", params={"user_id": "123", "inline_message_id": "abc"}
+        )
+
     assert response.status_code == HTTP_200_OK
     assert "Paco's Tapas Runner" in response.text
     # Check for the USER_ID initialization in script tag
     assert 'const USER_ID = "123";' in response.text
+    assert 'const GAME_TOKEN = "service-token";' in response.text
+    mock_generate_token.assert_called_once_with("123")
 
 
 @pytest.mark.asyncio
-async def test_submit_score_success(client):
+async def test_submit_score_does_not_award_reputation_twice(client):
     import hmac
     import time
 
@@ -70,5 +78,40 @@ async def test_submit_score_success(client):
             chat_id=None,
             message_id=None,
         )
-        # points = int(500 / 100) = 5
-        mock_add_points.assert_called_once_with("123", 5)
+        mock_add_points.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_score_uses_game_service_token_validation(client):
+    payload = {
+        "user_id": "123",
+        "score": 500,
+        "inline_message_id": "abc",
+        "token": "accepted-by-game-service",
+    }
+
+    with (
+        patch(
+            "services.game_service.GameService.verify_game_token",
+            return_value=True,
+            create=True,
+        ) as mock_verify_token,
+        patch(
+            "services.game_service.GameService.set_score", new_callable=AsyncMock
+        ) as mock_set_score,
+    ):
+        mock_set_score.return_value = True
+
+        response = client.post("/game/score", json=payload)
+
+        assert response.status_code == HTTP_201_CREATED
+        assert response.json() == {"status": "ok", "success": True}
+
+        mock_verify_token.assert_called_once_with("123", "accepted-by-game-service")
+        mock_set_score.assert_called_once_with(
+            user_id="123",
+            score=500,
+            inline_message_id="abc",
+            chat_id=None,
+            message_id=None,
+        )

--- a/src/api/web.py
+++ b/src/api/web.py
@@ -24,6 +24,7 @@ from services import (
     TTSService,
     UsageService,
     BadgeService,
+    GameService,
 )
 from core.config import config
 from utils.ui import apelativo
@@ -612,6 +613,7 @@ class WebController(Controller):
         tts_service: Annotated[TTSService, Dependency()],
         phrase_service: Annotated[PhraseService, Dependency()],
         user_service: Annotated[UserService, Dependency()],
+        game_service: Annotated[GameService, Dependency()],
     ) -> Template:
         """Launches the game from the web interface."""
         import datetime
@@ -667,6 +669,7 @@ class WebController(Controller):
                 "user_id": user_id,
                 "inline_message_id": None,
                 "game_short_name": "palillo_cunhao",
+                "game_token": game_service.generate_game_token(user_id),
                 "secret": config.session_secret,
                 "is_web": True,
                 "greeting_audio_url": greeting_audio_url,

--- a/src/api/web.py
+++ b/src/api/web.py
@@ -1,5 +1,4 @@
 import logging
-import asyncio
 import zlib
 from typing import Any, Annotated
 from litestar import Controller, Request, get, post
@@ -14,8 +13,6 @@ from infrastructure.protocols import (
     ProposalRepository,
     LongProposalRepository,
     UserRepository,
-    GiftRepository,
-    PosterRequestRepository,
 )
 from services import (
     PhraseService,
@@ -23,8 +20,8 @@ from services import (
     AIService,
     TTSService,
     UsageService,
-    BadgeService,
     GameService,
+    ProfileService,
 )
 from core.config import config
 from utils.ui import apelativo
@@ -146,12 +143,7 @@ class WebController(Controller):
         request: Request,
         user_id: str,
         user_repo: Annotated[UserRepository, Dependency()],
-        phrase_repo: Annotated[PhraseRepository, Dependency()],
-        long_phrase_repo: Annotated[LongPhraseRepository, Dependency()],
-        gift_repo: Annotated[GiftRepository, Dependency()],
-        badge_service: Annotated[BadgeService, Dependency()],
-        usage_service: Annotated[UsageService, Dependency()],
-        poster_request_repo: Annotated[PosterRequestRepository, Dependency()],
+        profile_service: Annotated[ProfileService, Dependency()],
     ) -> Template | Response:
         from models.gift import GIFT_EMOJIS, GIFT_NAMES
 
@@ -175,46 +167,8 @@ class WebController(Controller):
                 headers={"Location": f"/user/{profile_user.id}/profile"},
             )
 
-        # Parallelize data fetching
-        stats_task = usage_service.get_user_stats(profile_user.id)
-        badges_task = badge_service.get_all_badges_progress(
-            profile_user.id, profile_user.platform, user=profile_user
-        )
-        phrases_task = phrase_repo.get_phrases(user_id=str(profile_user.id))
-        long_phrases_task = long_phrase_repo.get_phrases(user_id=str(profile_user.id))
-        posters_task = poster_request_repo.get_completed_by_user(profile_user.id)
-
-        try:
-            gifts_task = gift_repo.get_gifts_for_user(int(profile_user.id))
-        except ValueError:
-            # Handle non-numeric IDs (e.g. Slack)
-            async def _empty_gifts():
-                return []
-
-            gifts_task = _empty_gifts()
-
-        (
-            stats,
-            badges_progress,
-            user_phrases,
-            user_long_phrases,
-            user_posters,
-            user_gifts,
-        ) = await asyncio.gather(
-            stats_task,
-            badges_task,
-            phrases_task,
-            long_phrases_task,
-            posters_task,
-            gifts_task,
-        )
-
-        all_user_phrases = sorted(
-            user_phrases + user_long_phrases, key=lambda x: x.usages, reverse=True
-        )
-
-        # Calculate Level (simple formula)
-        level = 1 + int(profile_user.points / 100)
+        # One coherent Perfil summary, shared with the bot profile views.
+        summary = await profile_service.get_profile_summary(profile_user)
 
         # Mock fun stats for now (could be improved with more complex queries)
         fun_stats = {}
@@ -225,15 +179,15 @@ class WebController(Controller):
                 "user": request.session.get("user"),
                 "owner_id": config.owner_id,
                 "profile_user": profile_user,
-                "stats": stats,
-                "badges_progress": badges_progress,
-                "user_phrases": all_user_phrases,
-                "user_posters": user_posters,
-                "user_gifts": user_gifts,
+                "stats": summary.stats,
+                "badges_progress": summary.badges_progress,
+                "user_phrases": summary.pieces,
+                "user_posters": summary.posters,
+                "user_gifts": summary.gifts,
                 "gift_emojis": GIFT_EMOJIS,
                 "gift_names": GIFT_NAMES,
-                "phrases_count": len(all_user_phrases),
-                "level": level,
+                "phrases_count": summary.pieces_count,
+                "level": summary.level,
                 "fun_stats": fun_stats,
                 "request": request,
             },

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -75,6 +75,10 @@ def mock_container():
         patch(
             "core.container.Container.profile_service", new_callable=PropertyMock
         ) as mock_profile_service_prop,
+        patch(
+            "core.container.Container.chat_interaction_service",
+            new_callable=PropertyMock,
+        ) as mock_chat_interaction_service_prop,
         patch.object(services, "user_repo") as mock_user_repo,
         patch.object(services, "chat_repo") as mock_chat_repo,
         patch.object(services, "phrase_repo") as mock_phrase_repo,
@@ -112,6 +116,9 @@ def mock_container():
         mock_profile_service = AsyncMock()
         mock_profile_service_prop.return_value = mock_profile_service
 
+        mock_chat_interaction_service = AsyncMock()
+        mock_chat_interaction_service_prop.return_value = mock_chat_interaction_service
+
         yield {
             "user_service": mock_user_service,
             "usage_service": mock_usage_service,
@@ -122,6 +129,7 @@ def mock_container():
             "tts_service": mock_tts_service,
             "cunhao_agent": mock_cunhao_agent,
             "profile_service": mock_profile_service,
+            "chat_interaction_service": mock_chat_interaction_service,
             "user_repo": mock_user_repo,
             "chat_repo": mock_chat_repo,
             "phrase_repo": mock_phrase_repo,

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -72,6 +72,9 @@ def mock_container():
         patch(
             "core.container.Container.cunhao_agent", new_callable=PropertyMock
         ) as mock_cunhao_agent_prop,
+        patch(
+            "core.container.Container.profile_service", new_callable=PropertyMock
+        ) as mock_profile_service_prop,
         patch.object(services, "user_repo") as mock_user_repo,
         patch.object(services, "chat_repo") as mock_chat_repo,
         patch.object(services, "phrase_repo") as mock_phrase_repo,
@@ -106,6 +109,9 @@ def mock_container():
         mock_cunhao_agent = AsyncMock()
         mock_cunhao_agent_prop.return_value = mock_cunhao_agent
 
+        mock_profile_service = AsyncMock()
+        mock_profile_service_prop.return_value = mock_profile_service
+
         yield {
             "user_service": mock_user_service,
             "usage_service": mock_usage_service,
@@ -115,6 +121,7 @@ def mock_container():
             "ai_service": mock_ai_service,
             "tts_service": mock_tts_service,
             "cunhao_agent": mock_cunhao_agent,
+            "profile_service": mock_profile_service,
             "user_repo": mock_user_repo,
             "chat_repo": mock_chat_repo,
             "phrase_repo": mock_phrase_repo,

--- a/src/core/container.py
+++ b/src/core/container.py
@@ -117,6 +117,7 @@ class Container:
                 long_repo=self.long_proposal_repo,
                 user_repo=self.user_repo,
                 user_service=self.user_service,
+                phrase_service=self.phrase_service,
             )
         return self._proposal_service
 

--- a/src/core/container.py
+++ b/src/core/container.py
@@ -26,6 +26,7 @@ from services import (
     AIService,
     TTSService,
     CunhaoAgent,
+    ProfileService,
 )
 
 if TYPE_CHECKING:
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
         UsageRepository,
         GiftRepository,
         LinkRequestRepository,
+        PosterRequestRepository,
     )
 
 
@@ -59,7 +61,7 @@ class Container:
         self.usage_repo: UsageRepository = usage_repository
         self.gift_repo: GiftRepository = gift_repository
         self.link_request_repo: LinkRequestRepository = link_request_repository
-        self.poster_request_repo = poster_request_repository
+        self.poster_request_repo: PosterRequestRepository = poster_request_repository
 
         # Services (Lazily initialized singletons)
         self._badge_service: BadgeService | None = None
@@ -71,6 +73,7 @@ class Container:
         self._tts_service: TTSService | None = None
         self._cunhao_agent: CunhaoAgent | None = None
         self._storage_service: StorageService | None = None
+        self._profile_service: ProfileService | None = None
 
     @property
     def badge_service(self) -> BadgeService:
@@ -157,6 +160,19 @@ class Container:
         if not self._storage_service:
             self._storage_service = StorageService(bucket_name=config.bucket_name)
         return self._storage_service
+
+    @property
+    def profile_service(self) -> ProfileService:
+        if not self._profile_service:
+            self._profile_service = ProfileService(
+                phrase_repo=self.phrase_repo,
+                long_phrase_repo=self.long_phrase_repo,
+                gift_repo=self.gift_repo,
+                poster_request_repo=self.poster_request_repo,
+                badge_service=self.badge_service,
+                usage_service=self.usage_service,
+            )
+        return self._profile_service
 
 
 # Global container instance

--- a/src/core/container.py
+++ b/src/core/container.py
@@ -28,6 +28,7 @@ from services import (
     CunhaoAgent,
     ProfileService,
     GameService,
+    ChatInteractionService,
 )
 
 if TYPE_CHECKING:
@@ -76,6 +77,7 @@ class Container:
         self._storage_service: StorageService | None = None
         self._profile_service: ProfileService | None = None
         self._game_service: GameService | None = None
+        self._chat_interaction_service: ChatInteractionService | None = None
 
     @property
     def badge_service(self) -> BadgeService:
@@ -171,6 +173,16 @@ class Container:
                 badge_service=self.badge_service,
             )
         return self._game_service
+
+    @property
+    def chat_interaction_service(self) -> ChatInteractionService:
+        if not self._chat_interaction_service:
+            self._chat_interaction_service = ChatInteractionService(
+                cunhao_agent=self.cunhao_agent,
+                ai_service=self.ai_service,
+                usage_service=self.usage_service,
+            )
+        return self._chat_interaction_service
 
     @property
     def profile_service(self) -> ProfileService:

--- a/src/core/container.py
+++ b/src/core/container.py
@@ -27,6 +27,7 @@ from services import (
     TTSService,
     CunhaoAgent,
     ProfileService,
+    GameService,
 )
 
 if TYPE_CHECKING:
@@ -74,6 +75,7 @@ class Container:
         self._cunhao_agent: CunhaoAgent | None = None
         self._storage_service: StorageService | None = None
         self._profile_service: ProfileService | None = None
+        self._game_service: GameService | None = None
 
     @property
     def badge_service(self) -> BadgeService:
@@ -160,6 +162,15 @@ class Container:
         if not self._storage_service:
             self._storage_service = StorageService(bucket_name=config.bucket_name)
         return self._storage_service
+
+    @property
+    def game_service(self) -> GameService:
+        if not self._game_service:
+            self._game_service = GameService(
+                user_repo=self.user_repo,
+                badge_service=self.badge_service,
+            )
+        return self._game_service
 
     @property
     def profile_service(self) -> ProfileService:

--- a/src/core/di.py
+++ b/src/core/di.py
@@ -1,188 +1,46 @@
+"""Litestar dependency wiring.
+
+The `Container` in ``core.container`` is the single composition root for the
+whole app (Litestar, Telegram and CLI). Here we only expose its singletons to
+Litestar's DI by name, so wiring lives in one place and cannot drift between
+the web app and the bot.
+"""
+
 from litestar.di import Provide
-from core.config import config
-from utils.gcp import get_bucket
 
-from infrastructure.datastore.phrase import phrase_repository, long_phrase_repository
-from infrastructure.datastore.proposal import (
-    proposal_repository,
-    long_proposal_repository,
-)
-from infrastructure.datastore.user import user_repository
-from infrastructure.datastore.chat import chat_repository
-from infrastructure.datastore.usage import usage_repository
-from infrastructure.datastore.poster_request import poster_request_repository
-from infrastructure.datastore.gift import gift_repository
-from infrastructure.datastore.link_request import link_request_repository
-
-from services import (
-    PhraseService,
-    ProposalService,
-    UserService,
-    GameService,
-    AIService,
-    TTSService,
-    BadgeService,
-    UsageService,
-    CunhaoAgent,
-    ProfileService,
-)
-
-from infrastructure.protocols import (
-    PhraseRepository,
-    LongPhraseRepository,
-    ProposalRepository,
-    LongProposalRepository,
-    UserRepository,
-    ChatRepository,
-    UsageRepository,
-    GiftRepository,
-    LinkRequestRepository,
-    PosterRequestRepository,
-)
-
-
-def provide_badge_service(
-    user_repo: UserRepository,
-    usage_repo: UsageRepository,
-    phrase_repo: PhraseRepository,
-    long_phrase_repo: LongPhraseRepository,
-    gift_repo: GiftRepository,
-) -> BadgeService:
-    return BadgeService(
-        user_repo=user_repo,
-        usage_repo=usage_repo,
-        phrase_repo=phrase_repo,
-        long_phrase_repo=long_phrase_repo,
-        gift_repo=gift_repo,
-    )
-
-
-def provide_user_service(
-    user_repo: UserRepository,
-    chat_repo: ChatRepository,
-    phrase_repo: PhraseRepository,
-    long_phrase_repo: LongPhraseRepository,
-    proposal_repo: ProposalRepository,
-    long_proposal_repo: LongProposalRepository,
-    link_request_repo: LinkRequestRepository,
-) -> UserService:
-    return UserService(
-        user_repo=user_repo,
-        chat_repo=chat_repo,
-        phrase_repo=phrase_repo,
-        long_phrase_repo=long_phrase_repo,
-        proposal_repo=proposal_repo,
-        long_proposal_repo=long_proposal_repo,
-        link_request_repo=link_request_repo,
-    )
-
-
-def provide_phrase_service(
-    phrase_repo: PhraseRepository,
-    long_phrase_repo: LongPhraseRepository,
-    user_service: UserService,
-    badge_service: BadgeService,
-) -> PhraseService:
-    return PhraseService(
-        phrase_repo=phrase_repo,
-        long_phrase_repo=long_phrase_repo,
-        user_service=user_service,
-        badge_service=badge_service,
-    )
-
-
-def provide_proposal_service(
-    proposal_repo: ProposalRepository,
-    long_proposal_repo: LongProposalRepository,
-    user_repo: UserRepository,
-    user_service: UserService,
-    phrase_service: PhraseService,
-) -> ProposalService:
-    return ProposalService(
-        repo=proposal_repo,
-        long_repo=long_proposal_repo,
-        user_repo=user_repo,
-        user_service=user_service,
-        phrase_service=phrase_service,
-    )
-
-
-def provide_usage_service(
-    usage_repo: UsageRepository,
-    user_service: UserService,
-    badge_service: BadgeService,
-) -> UsageService:
-    return UsageService(
-        repo=usage_repo,
-        user_service=user_service,
-        badge_service=badge_service,
-    )
-
-
-def provide_ai_service(phrase_service: PhraseService) -> AIService:
-    return AIService(
-        api_key=config.gemini_api_key or "dummy",
-        phrase_service=phrase_service,
-    )
-
-
-def provide_game_service(
-    user_repo: UserRepository, badge_service: BadgeService
-) -> GameService:
-    return GameService(user_repo=user_repo, badge_service=badge_service)
-
-
-def provide_profile_service(
-    phrase_repo: PhraseRepository,
-    long_phrase_repo: LongPhraseRepository,
-    gift_repo: GiftRepository,
-    poster_request_repo: PosterRequestRepository,
-    badge_service: BadgeService,
-    usage_service: UsageService,
-) -> ProfileService:
-    return ProfileService(
-        phrase_repo=phrase_repo,
-        long_phrase_repo=long_phrase_repo,
-        gift_repo=gift_repo,
-        poster_request_repo=poster_request_repo,
-        badge_service=badge_service,
-        usage_service=usage_service,
-    )
-
-
-def provide_tts_service() -> TTSService:
-    return TTSService(bucket=get_bucket())
-
-
-def provide_cunhao_agent() -> CunhaoAgent:
-    return CunhaoAgent(api_key=config.gemini_api_key or "dummy")
-
+from core.container import services
 
 dependencies = {
     # Repositories
-    "phrase_repo": Provide(lambda: phrase_repository, sync_to_thread=False),
-    "long_phrase_repo": Provide(lambda: long_phrase_repository, sync_to_thread=False),
-    "proposal_repo": Provide(lambda: proposal_repository, sync_to_thread=False),
+    "phrase_repo": Provide(lambda: services.phrase_repo, sync_to_thread=False),
+    "long_phrase_repo": Provide(
+        lambda: services.long_phrase_repo, sync_to_thread=False
+    ),
+    "proposal_repo": Provide(lambda: services.proposal_repo, sync_to_thread=False),
     "long_proposal_repo": Provide(
-        lambda: long_proposal_repository, sync_to_thread=False
+        lambda: services.long_proposal_repo, sync_to_thread=False
     ),
-    "user_repo": Provide(lambda: user_repository, sync_to_thread=False),
-    "chat_repo": Provide(lambda: chat_repository, sync_to_thread=False),
-    "usage_repo": Provide(lambda: usage_repository, sync_to_thread=False),
-    "link_request_repo": Provide(lambda: link_request_repository, sync_to_thread=False),
+    "user_repo": Provide(lambda: services.user_repo, sync_to_thread=False),
+    "chat_repo": Provide(lambda: services.chat_repo, sync_to_thread=False),
+    "usage_repo": Provide(lambda: services.usage_repo, sync_to_thread=False),
+    "link_request_repo": Provide(
+        lambda: services.link_request_repo, sync_to_thread=False
+    ),
     "poster_request_repo": Provide(
-        lambda: poster_request_repository, sync_to_thread=False
+        lambda: services.poster_request_repo, sync_to_thread=False
     ),
-    "gift_repo": Provide(lambda: gift_repository, sync_to_thread=False),
+    "gift_repo": Provide(lambda: services.gift_repo, sync_to_thread=False),
     # Services
-    "badge_service": Provide(provide_badge_service, sync_to_thread=False),
-    "user_service": Provide(provide_user_service, sync_to_thread=False),
-    "phrase_service": Provide(provide_phrase_service, sync_to_thread=False),
-    "proposal_service": Provide(provide_proposal_service, sync_to_thread=False),
-    "usage_service": Provide(provide_usage_service, sync_to_thread=False),
-    "ai_service": Provide(provide_ai_service, sync_to_thread=False),
-    "tts_service": Provide(provide_tts_service, sync_to_thread=False),
-    "game_service": Provide(provide_game_service, sync_to_thread=False),
-    "profile_service": Provide(provide_profile_service, sync_to_thread=False),
-    "cunhao_agent": Provide(provide_cunhao_agent, sync_to_thread=False),
+    "badge_service": Provide(lambda: services.badge_service, sync_to_thread=False),
+    "user_service": Provide(lambda: services.user_service, sync_to_thread=False),
+    "phrase_service": Provide(lambda: services.phrase_service, sync_to_thread=False),
+    "proposal_service": Provide(
+        lambda: services.proposal_service, sync_to_thread=False
+    ),
+    "usage_service": Provide(lambda: services.usage_service, sync_to_thread=False),
+    "ai_service": Provide(lambda: services.ai_service, sync_to_thread=False),
+    "tts_service": Provide(lambda: services.tts_service, sync_to_thread=False),
+    "game_service": Provide(lambda: services.game_service, sync_to_thread=False),
+    "profile_service": Provide(lambda: services.profile_service, sync_to_thread=False),
+    "cunhao_agent": Provide(lambda: services.cunhao_agent, sync_to_thread=False),
 }

--- a/src/core/di.py
+++ b/src/core/di.py
@@ -24,6 +24,7 @@ from services import (
     BadgeService,
     UsageService,
     CunhaoAgent,
+    ProfileService,
 )
 
 from infrastructure.protocols import (
@@ -36,6 +37,7 @@ from infrastructure.protocols import (
     UsageRepository,
     GiftRepository,
     LinkRequestRepository,
+    PosterRequestRepository,
 )
 
 
@@ -130,6 +132,24 @@ def provide_game_service(
     return GameService(user_repo=user_repo, badge_service=badge_service)
 
 
+def provide_profile_service(
+    phrase_repo: PhraseRepository,
+    long_phrase_repo: LongPhraseRepository,
+    gift_repo: GiftRepository,
+    poster_request_repo: PosterRequestRepository,
+    badge_service: BadgeService,
+    usage_service: UsageService,
+) -> ProfileService:
+    return ProfileService(
+        phrase_repo=phrase_repo,
+        long_phrase_repo=long_phrase_repo,
+        gift_repo=gift_repo,
+        poster_request_repo=poster_request_repo,
+        badge_service=badge_service,
+        usage_service=usage_service,
+    )
+
+
 def provide_tts_service() -> TTSService:
     return TTSService(bucket=get_bucket())
 
@@ -163,5 +183,6 @@ dependencies = {
     "ai_service": Provide(provide_ai_service, sync_to_thread=False),
     "tts_service": Provide(provide_tts_service, sync_to_thread=False),
     "game_service": Provide(provide_game_service, sync_to_thread=False),
+    "profile_service": Provide(provide_profile_service, sync_to_thread=False),
     "cunhao_agent": Provide(provide_cunhao_agent, sync_to_thread=False),
 }

--- a/src/core/di.py
+++ b/src/core/di.py
@@ -43,4 +43,7 @@ dependencies = {
     "game_service": Provide(lambda: services.game_service, sync_to_thread=False),
     "profile_service": Provide(lambda: services.profile_service, sync_to_thread=False),
     "cunhao_agent": Provide(lambda: services.cunhao_agent, sync_to_thread=False),
+    "chat_interaction_service": Provide(
+        lambda: services.chat_interaction_service, sync_to_thread=False
+    ),
 }

--- a/src/core/di.py
+++ b/src/core/di.py
@@ -94,12 +94,14 @@ def provide_proposal_service(
     long_proposal_repo: LongProposalRepository,
     user_repo: UserRepository,
     user_service: UserService,
+    phrase_service: PhraseService,
 ) -> ProposalService:
     return ProposalService(
         repo=proposal_repo,
         long_repo=long_proposal_repo,
         user_repo=user_repo,
         user_service=user_service,
+        phrase_service=phrase_service,
     )
 
 

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -8,6 +8,7 @@ from services.usage_service import UsageService
 from services.badge_service import BadgeService
 from services.game_service import GameService
 from services.profile_service import ProfileService
+from services.chat_interaction_service import ChatInteractionService
 
 __all__ = [
     "PhraseService",
@@ -20,4 +21,5 @@ __all__ = [
     "BadgeService",
     "GameService",
     "ProfileService",
+    "ChatInteractionService",
 ]

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -7,6 +7,7 @@ from services.cunhao_agent import CunhaoAgent
 from services.usage_service import UsageService
 from services.badge_service import BadgeService
 from services.game_service import GameService
+from services.profile_service import ProfileService
 
 __all__ = [
     "PhraseService",
@@ -18,4 +19,5 @@ __all__ = [
     "UsageService",
     "BadgeService",
     "GameService",
+    "ProfileService",
 ]

--- a/src/services/badge_service_test.py
+++ b/src/services/badge_service_test.py
@@ -135,3 +135,25 @@ async def test_check_badges_awards_pesao(badge_service, mock_usage_repo):
     assert "pesao" in user.badges
     assert len(user.last_usages) == 10
     badge_service.user_service.save_user.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_check_badges_awards_each_logro_once(badge_service, mock_usage_repo):
+    """User story 21: a Logro is awarded once. Re-evaluating a milestone a
+    Perfil already holds must not return it again nor duplicate it on the user.
+    These rules are exercised without any Telegram or Slack object."""
+    user = User(id="123", badges=[])
+    badge_service.user_service.get_user = AsyncMock(return_value=user)
+
+    mock_usage_repo.get_user_usage_count.return_value = 1
+    mock_usage_repo.get_user_action_count.return_value = 0
+    # Meets the Poeta milestone (>= 5 authored Apelativos).
+    badge_service.phrase_repo.get_user_phrase_count.return_value = 5
+
+    first = await badge_service.check_badges("123", "telegram")
+    assert any(b.id == "poeta" for b in first)
+
+    # Second evaluation with the milestone still met: no re-award, no duplicate.
+    second = await badge_service.check_badges("123", "telegram")
+    assert all(b.id != "poeta" for b in second)
+    assert user.badges.count("poeta") == 1

--- a/src/services/chat_interaction_service.py
+++ b/src/services/chat_interaction_service.py
@@ -1,0 +1,75 @@
+"""Shared Chat interaction behavior across platform adapters.
+
+Telegram and Slack apply the same product rules when Cunhaobot talks in a
+Chat: an AI answer counts as an AI_ASK Uso, and a delivered smart reaction
+counts as a REACTION_RECEIVED Uso. This module owns those rules so the
+platform handlers only translate events and render the response/reaction in
+their own SDK.
+
+Premium gating is intentionally NOT here: it varies by platform (currently
+Telegram-only), and a seam is only introduced where behavior is shared.
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from models.usage import ActionType
+
+if TYPE_CHECKING:
+    from services.cunhao_agent import CunhaoAgent
+    from services.ai_service import AIService
+    from services.usage_service import UsageService
+    from services.badge_service import Badge
+
+
+@dataclass(frozen=True)
+class AIReply:
+    """An AI answer plus any Logros unlocked by logging the AI_ASK Uso."""
+
+    text: str
+    new_badges: "list[Badge]" = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ReactionDecision:
+    """The smart-reaction emoji to apply, or None when no reaction is warranted."""
+
+    emoji: str | None = None
+
+
+class ChatInteractionService:
+    def __init__(
+        self,
+        cunhao_agent: "CunhaoAgent",
+        ai_service: "AIService",
+        usage_service: "UsageService",
+    ):
+        self.cunhao_agent = cunhao_agent
+        self.ai_service = ai_service
+        self.usage_service = usage_service
+
+    async def answer(self, *, user_id: str | int, platform: str, text: str) -> AIReply:
+        """Produce the AI answer for a Chat message and record the AI_ASK Uso."""
+        response = await self.cunhao_agent.answer(text)
+        new_badges = await self.usage_service.log_usage(
+            user_id=user_id, platform=platform, action=ActionType.AI_ASK
+        )
+        return AIReply(text=response, new_badges=new_badges or [])
+
+    async def decide_reaction(self, text: str) -> ReactionDecision:
+        """Decide which smart reaction (if any) a Chat message warrants.
+
+        The Uso is only recorded once the platform actually delivers the
+        reaction, via :meth:`record_reaction_received`.
+        """
+        emoji = await self.ai_service.analyze_sentiment_and_react(text)
+        return ReactionDecision(emoji=emoji or None)
+
+    async def record_reaction_received(
+        self, *, user_id: str | int, platform: str
+    ) -> "list[Badge]":
+        """Record a delivered smart reaction as a REACTION_RECEIVED Uso."""
+        new_badges = await self.usage_service.log_usage(
+            user_id=user_id, platform=platform, action=ActionType.REACTION_RECEIVED
+        )
+        return new_badges or []

--- a/src/services/chat_interaction_service_test.py
+++ b/src/services/chat_interaction_service_test.py
@@ -1,0 +1,74 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from models.usage import ActionType
+from services.chat_interaction_service import (
+    AIReply,
+    ChatInteractionService,
+    ReactionDecision,
+)
+
+
+class TestChatInteractionService:
+    """Telegram and Slack share the same Chat interaction product rules: an AI
+    answer is an AI_ASK Uso, and a delivered smart reaction is a
+    REACTION_RECEIVED Uso. The service owns that behavior so platform handlers
+    only translate events and render responses."""
+
+    @pytest.fixture
+    def service(self):
+        self.cunhao_agent = AsyncMock()
+        self.ai_service = AsyncMock()
+        self.usage_service = AsyncMock()
+        return ChatInteractionService(
+            cunhao_agent=self.cunhao_agent,
+            ai_service=self.ai_service,
+            usage_service=self.usage_service,
+        )
+
+    @pytest.mark.asyncio
+    async def test_answer_logs_ai_ask_and_returns_reply(self, service):
+        self.cunhao_agent.answer.return_value = "Pues mira, chaval"
+        self.usage_service.log_usage.return_value = ["badge1"]
+
+        reply = await service.answer(user_id="U1", platform="slack", text="¿qué tal?")
+
+        assert isinstance(reply, AIReply)
+        assert reply.text == "Pues mira, chaval"
+        assert reply.new_badges == ["badge1"]
+        self.cunhao_agent.answer.assert_awaited_once_with("¿qué tal?")
+        self.usage_service.log_usage.assert_awaited_once_with(
+            user_id="U1", platform="slack", action=ActionType.AI_ASK
+        )
+
+    @pytest.mark.asyncio
+    async def test_decide_reaction_returns_emoji_without_logging(self, service):
+        # Deciding the reaction is the shared product rule; rendering and the
+        # REACTION_RECEIVED Uso happen after the platform applies it.
+        self.ai_service.analyze_sentiment_and_react.return_value = "🔥"
+
+        decision = await service.decide_reaction("menudo crack")
+
+        assert decision == ReactionDecision(emoji="🔥")
+        self.usage_service.log_usage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_decide_reaction_none_when_no_sentiment(self, service):
+        self.ai_service.analyze_sentiment_and_react.return_value = None
+
+        decision = await service.decide_reaction("texto neutro")
+
+        assert decision.emoji is None
+
+    @pytest.mark.asyncio
+    async def test_record_reaction_received_logs_usage(self, service):
+        self.usage_service.log_usage.return_value = ["centro_atencion"]
+
+        badges = await service.record_reaction_received(
+            user_id=123, platform="telegram"
+        )
+
+        assert badges == ["centro_atencion"]
+        self.usage_service.log_usage.assert_awaited_once_with(
+            user_id=123, platform="telegram", action=ActionType.REACTION_RECEIVED
+        )

--- a/src/services/game_service.py
+++ b/src/services/game_service.py
@@ -1,11 +1,26 @@
-import logging
 import hashlib
+import hmac
+import logging
+import time
 from datetime import datetime, timezone, timedelta
+from pydantic import BaseModel
 from infrastructure.protocols import UserRepository
+from models.user import User
 from services.badge_service import BadgeService
 from core.config import config
 
 logger = logging.getLogger(__name__)
+
+
+class InvalidGameSessionError(Exception):
+    """Raised when a game score is submitted outside a valid game session."""
+
+
+class GamePlayerProfile(BaseModel):
+    user_id: str | int
+    name: str = "Usuario Web"
+    username: str | None = None
+    platform: str = "telegram"
 
 
 class GameService:
@@ -24,6 +39,99 @@ class GameService:
         ).hexdigest()
 
         return hash_val == expected_hash
+
+    def generate_game_token(self, user_id: str | int) -> str:
+        timestamp = int(time.time())
+        payload = f"{user_id}:{timestamp}"
+        signature = hmac.new(
+            config.session_secret.encode(), payload.encode(), hashlib.sha256
+        ).hexdigest()
+        return f"{signature}:{timestamp}"
+
+    def verify_game_token(self, user_id: str | int, token: str) -> bool:
+        try:
+            signature, timestamp_str = token.split(":")
+            timestamp = int(timestamp_str)
+        except (ValueError, AttributeError):
+            return False
+
+        if time.time() - timestamp > 7200:
+            return False
+
+        payload = f"{user_id}:{timestamp}"
+        expected_signature = hmac.new(
+            config.session_secret.encode(), payload.encode(), hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(signature, expected_signature)
+
+    async def submit_score(
+        self,
+        user_id: str | int,
+        score: int,
+        token: str,
+        inline_message_id: str | None = None,
+        chat_id: str | int | None = None,
+        message_id: str | int | None = None,
+        player_profile: GamePlayerProfile | None = None,
+    ) -> bool:
+        if not self.verify_game_token(user_id, token):
+            raise InvalidGameSessionError
+
+        success = await self.set_score(
+            user_id=str(user_id),
+            score=score,
+            inline_message_id=inline_message_id,
+            chat_id=chat_id,
+            message_id=message_id,
+        )
+        if success or user_id == "guest":
+            return success
+
+        if player_profile is None or str(player_profile.user_id) != str(user_id):
+            return False
+
+        await self._ensure_player_profile(player_profile)
+        return await self.set_score(
+            user_id=str(user_id),
+            score=score,
+            inline_message_id=inline_message_id,
+            chat_id=chat_id,
+            message_id=message_id,
+        )
+
+    async def _ensure_player_profile(self, profile: GamePlayerProfile) -> None:
+        uid_to_load = profile.user_id
+        if isinstance(profile.user_id, str) and profile.user_id.lstrip("-").isdigit():
+            uid_to_load = int(profile.user_id)
+
+        user = await self.user_repo.load(uid_to_load)
+        if not user and isinstance(uid_to_load, int):
+            user = await self.user_repo.load(str(uid_to_load))
+
+        if not user:
+            await self.user_repo.save(
+                User(
+                    id=profile.user_id,
+                    name=profile.name,
+                    username=profile.username,
+                    platform=profile.platform,
+                )
+            )
+            return
+
+        changed = False
+        if user.name != profile.name:
+            user.name = profile.name
+            changed = True
+        if user.username != profile.username:
+            user.username = profile.username
+            changed = True
+        if user.platform != profile.platform and str(user.id) == str(profile.user_id):
+            user.platform = profile.platform
+            changed = True
+
+        if changed:
+            await self.user_repo.save(user)
 
     async def set_score(
         self,

--- a/src/services/game_service.py
+++ b/src/services/game_service.py
@@ -28,18 +28,6 @@ class GameService:
         self.user_repo = user_repo
         self.badge_service = badge_service
 
-    def verify_score_hash(self, user_id: str, score: int, hash_val: str) -> bool:
-        """Verifies if the score has been tampered with."""
-        if hash_val.startswith("unsafe-"):
-            # Fallback for non-HTTPS environments (dev/tests)
-            return True
-
-        expected_hash = hashlib.sha256(
-            f"{user_id}{score}{config.session_secret}".encode()
-        ).hexdigest()
-
-        return hash_val == expected_hash
-
     def generate_game_token(self, user_id: str | int) -> str:
         timestamp = int(time.time())
         payload = f"{user_id}:{timestamp}"

--- a/src/services/game_service_test.py
+++ b/src/services/game_service_test.py
@@ -1,7 +1,39 @@
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from datetime import datetime, timezone, timedelta
-from services.game_service import GameService
+from services.game_service import GamePlayerProfile, GameService
+from models.user import User
+
+
+class InMemoryUserRepository:
+    def __init__(self) -> None:
+        self.users: dict[str | int, User] = {}
+        self.saved: list[User] = []
+
+    async def save(self, entity: User) -> None:
+        self.users[entity.id] = entity
+        self.saved.append(entity)
+
+    async def delete(self, entity_id: str | int) -> None:
+        self.users.pop(entity_id, None)
+
+    async def load(self, entity_id: str | int) -> User | None:
+        return self.users.get(entity_id)
+
+    async def load_all(self, ignore_gdpr: bool = False) -> list[User]:
+        return list(self.users.values())
+
+    def clear_cache(self) -> None:
+        return None
+
+    async def load_raw(self, entity_id: str | int) -> User | None:
+        return await self.load(entity_id)
+
+    async def get_by_username(self, username: str) -> User | None:
+        return next(
+            (user for user in self.users.values() if user.username == username),
+            None,
+        )
 
 
 @pytest.mark.asyncio
@@ -68,3 +100,32 @@ async def test_process_score_streak():
     with patch("tg.get_initialized_tg_application", new_callable=AsyncMock):
         await service.set_score(user_id, 100)
         assert mock_user.game_streak == 6
+
+
+@pytest.mark.asyncio
+async def test_submit_score_creates_matching_web_profile_before_saving_score():
+    user_repo = InMemoryUserRepository()
+    badge_service = AsyncMock()
+    badge_service.check_badges.return_value = []
+    service = GameService(user_repo, badge_service)
+    token = service.generate_game_token("123")
+
+    with patch("tg.get_initialized_tg_application", new_callable=AsyncMock):
+        result = await service.submit_score(
+            user_id="123",
+            score=450,
+            token=token,
+            player_profile=GamePlayerProfile(
+                user_id="123",
+                name="Web Player",
+                username="web_player",
+            ),
+        )
+
+    assert result is True
+    stored_user = user_repo.users["123"]
+    assert stored_user.name == "Web Player"
+    assert stored_user.username == "web_player"
+    assert stored_user.points == 4
+    assert stored_user.game_stats == 1
+    assert stored_user.game_high_score == 450

--- a/src/services/payment.py
+++ b/src/services/payment.py
@@ -1,0 +1,102 @@
+"""Centralized parsing of Telegram payment payloads.
+
+Paid fulfillment covers three products — Regalo, Póster and Suscripción
+Premium — that historically were distinguished by ad hoc ``startswith`` checks
+and inline ``split`` parsing inside the payment handler. This module turns a
+raw payload string into a typed payment intent so callers route on the parsed
+result instead of reasoning about string prefixes.
+"""
+
+from dataclasses import dataclass
+
+from models.gift import GiftType
+
+
+@dataclass(frozen=True)
+class GiftPayment:
+    """A Regalo from one Perfil to another within a Chat."""
+
+    receiver_id: int
+    gift_type: GiftType
+    chat_id: int | None = None
+
+
+@dataclass(frozen=True)
+class SubscriptionPayment:
+    """A Suscripción Premium extension scoped to a Chat."""
+
+    target_chat_id: int
+
+
+@dataclass(frozen=True)
+class PosterPayment:
+    """A Póster request, identified by its stored request id (or legacy phrase)."""
+
+    payload: str
+
+
+ParsedPayment = GiftPayment | SubscriptionPayment | PosterPayment
+
+_GIFT_PREFIX = "gift:"
+_SUBSCRIPTION_PREFIX = "subs_month_"
+
+
+class InvalidPaymentPayload(ValueError):
+    """Raised when a payment payload cannot be parsed into a known intent."""
+
+
+def parse_payment_payload(payload: str) -> ParsedPayment:
+    """Parse a raw invoice payload into a typed payment intent.
+
+    Raises ``InvalidPaymentPayload`` for empty or malformed Regalo/Suscripción
+    payloads. Any unrecognized payload is treated as a Póster request id, which
+    preserves the historical fallback where the payload could be a plain phrase.
+    """
+    if not payload:
+        raise InvalidPaymentPayload("empty payload")
+
+    if payload.startswith(_GIFT_PREFIX):
+        return _parse_gift(payload)
+
+    if payload.startswith(_SUBSCRIPTION_PREFIX):
+        return _parse_subscription(payload)
+
+    return PosterPayment(payload=payload)
+
+
+def _parse_gift(payload: str) -> GiftPayment:
+    parts = payload.split(":")
+    # Modern: gift:chat_id:receiver_id:gift_type
+    # Legacy: gift:receiver_id:gift_type (delivered in the originating chat)
+    if len(parts) == 4:
+        _, chat_id_str, receiver_id_str, gift_type_str = parts
+        chat_id: int | None = _to_int(chat_id_str, payload)
+    elif len(parts) == 3:
+        _, receiver_id_str, gift_type_str = parts
+        chat_id = None
+    else:
+        raise InvalidPaymentPayload(f"malformed gift payload: {payload!r}")
+
+    receiver_id = _to_int(receiver_id_str, payload)
+    try:
+        gift_type = GiftType(gift_type_str)
+    except ValueError as exc:
+        raise InvalidPaymentPayload(
+            f"unknown gift type {gift_type_str!r} in {payload!r}"
+        ) from exc
+
+    return GiftPayment(receiver_id=receiver_id, gift_type=gift_type, chat_id=chat_id)
+
+
+def _parse_subscription(payload: str) -> SubscriptionPayment:
+    target_chat_id = _to_int(payload.replace(_SUBSCRIPTION_PREFIX, "", 1), payload)
+    return SubscriptionPayment(target_chat_id=target_chat_id)
+
+
+def _to_int(value: str, payload: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise InvalidPaymentPayload(
+            f"expected integer, got {value!r} in {payload!r}"
+        ) from exc

--- a/src/services/payment_test.py
+++ b/src/services/payment_test.py
@@ -1,0 +1,54 @@
+import pytest
+
+from models.gift import GiftType
+from services.payment import (
+    GiftPayment,
+    InvalidPaymentPayload,
+    PosterPayment,
+    SubscriptionPayment,
+    parse_payment_payload,
+)
+
+
+class TestParsePaymentPayload:
+    """Paid fulfillment payload parsing is centralized so Regalo, Póster and
+    Suscripción Premium no longer depend on ad hoc string handling spread
+    across the payment handler."""
+
+    def test_gift_with_chat(self):
+        result = parse_payment_payload("gift:-100:200:palillo")
+        assert result == GiftPayment(
+            chat_id=-100, receiver_id=200, gift_type=GiftType.PALILLO
+        )
+
+    def test_gift_legacy_without_chat(self):
+        result = parse_payment_payload("gift:200:cognac")
+        assert isinstance(result, GiftPayment)
+        assert result.chat_id is None
+        assert result.receiver_id == 200
+        assert result.gift_type is GiftType.COGNAC
+
+    def test_subscription(self):
+        result = parse_payment_payload("subs_month_-1009999")
+        assert result == SubscriptionPayment(target_chat_id=-1009999)
+
+    def test_poster_request_id(self):
+        # Anything else is treated as a Póster request id (or legacy phrase).
+        result = parse_payment_payload("poster-abc-123")
+        assert result == PosterPayment(payload="poster-abc-123")
+
+    def test_empty_payload_is_invalid(self):
+        with pytest.raises(InvalidPaymentPayload):
+            parse_payment_payload("")
+
+    def test_gift_invalid_type_is_invalid(self):
+        with pytest.raises(InvalidPaymentPayload):
+            parse_payment_payload("gift:-100:200:diamond")
+
+    def test_gift_non_numeric_receiver_is_invalid(self):
+        with pytest.raises(InvalidPaymentPayload):
+            parse_payment_payload("gift:-100:abc:palillo")
+
+    def test_subscription_non_numeric_is_invalid(self):
+        with pytest.raises(InvalidPaymentPayload):
+            parse_payment_payload("subs_month_notanumber")

--- a/src/services/profile_service.py
+++ b/src/services/profile_service.py
@@ -1,0 +1,112 @@
+"""Perfil aggregation.
+
+Web, Telegram and Slack profile views all need the same coherent Perfil
+summary: Puntos de reputación, Logros, authored Pieza cuñadil, Regalos and
+Pósters. This module assembles that summary once so callers stop rebuilding
+the same statistics in different ways.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from models.user import User
+from models.phrase import Phrase
+
+if TYPE_CHECKING:
+    from infrastructure.protocols import (
+        PhraseRepository,
+        LongPhraseRepository,
+        GiftRepository,
+        PosterRequestRepository,
+    )
+    from models.gift import Gift
+    from models.poster_request import PosterRequest
+    from services.badge_service import Badge, BadgeProgress, BadgeService
+    from services.usage_service import UsageService
+
+
+@dataclass(frozen=True)
+class ProfileSummary:
+    """A coherent snapshot of a Perfil for any profile presentation."""
+
+    user: User
+    stats: dict[str, int]
+    badges_progress: "list[BadgeProgress]"
+    pieces: list[Phrase]
+    posters: "list[PosterRequest]"
+    gifts: "list[Gift]"
+    level: int
+
+    @property
+    def points(self) -> int:
+        return self.user.points
+
+    @property
+    def earned_badges(self) -> "list[Badge]":
+        return [p.badge for p in self.badges_progress if p.is_earned]
+
+    @property
+    def pieces_count(self) -> int:
+        return len(self.pieces)
+
+
+class ProfileService:
+    def __init__(
+        self,
+        phrase_repo: "PhraseRepository",
+        long_phrase_repo: "LongPhraseRepository",
+        gift_repo: "GiftRepository",
+        poster_request_repo: "PosterRequestRepository",
+        badge_service: "BadgeService",
+        usage_service: "UsageService",
+    ):
+        self.phrase_repo = phrase_repo
+        self.long_phrase_repo = long_phrase_repo
+        self.gift_repo = gift_repo
+        self.poster_request_repo = poster_request_repo
+        self.badge_service = badge_service
+        self.usage_service = usage_service
+
+    async def get_profile_summary(self, user: User) -> ProfileSummary:
+        """Aggregate the canonical Perfil summary for a resolved Perfil."""
+        user_key = str(user.id)
+        (
+            stats,
+            badges_progress,
+            phrases,
+            long_phrases,
+            posters,
+            gifts,
+        ) = await asyncio.gather(
+            self.usage_service.get_user_stats(user.id),
+            self.badge_service.get_all_badges_progress(
+                user.id, user.platform, user=user
+            ),
+            self.phrase_repo.get_phrases(user_id=user_key),
+            self.long_phrase_repo.get_phrases(user_id=user_key),
+            self.poster_request_repo.get_completed_by_user(user.id),
+            self._gifts_for(user),
+        )
+
+        # Apelativo and Frase cuñadil share one repertory in the summary.
+        pieces = sorted([*phrases, *long_phrases], key=lambda p: p.usages, reverse=True)
+        level = 1 + int(user.points / 100)
+
+        return ProfileSummary(
+            user=user,
+            stats=stats,
+            badges_progress=badges_progress,
+            pieces=pieces,
+            posters=posters,
+            gifts=gifts,
+            level=level,
+        )
+
+    async def _gifts_for(self, user: User) -> "list[Gift]":
+        # Regalos are keyed by numeric id; Slack Perfiles have non-numeric ids.
+        try:
+            numeric_id = int(user.id)
+        except (TypeError, ValueError):
+            return []
+        return await self.gift_repo.get_gifts_for_user(numeric_id)

--- a/src/services/profile_service_test.py
+++ b/src/services/profile_service_test.py
@@ -1,0 +1,115 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from models.user import User
+from models.phrase import Phrase, LongPhrase
+from services.badge_service import Badge, BadgeProgress
+from services.profile_service import ProfileService, ProfileSummary
+
+
+def _progress(badge_id: str, is_earned: bool) -> BadgeProgress:
+    return BadgeProgress(
+        badge=Badge(id=badge_id, name=badge_id.title(), description="", icon="🏅"),
+        is_earned=is_earned,
+        progress=100 if is_earned else 0,
+        current=1 if is_earned else 0,
+        target=1,
+    )
+
+
+class TestProfileService:
+    """Profile aggregation sits behind one interface so web, Telegram and Slack
+    profile views consume a coherent Perfil summary instead of reassembling
+    Puntos de reputación, Logros, Pieza cuñadil, Regalos and Pósters
+    independently."""
+
+    @pytest.fixture
+    def service(self):
+        self.phrase_repo = AsyncMock()
+        self.long_phrase_repo = AsyncMock()
+        self.gift_repo = AsyncMock()
+        self.poster_request_repo = AsyncMock()
+        self.badge_service = AsyncMock()
+        self.usage_service = AsyncMock()
+        return ProfileService(
+            phrase_repo=self.phrase_repo,
+            long_phrase_repo=self.long_phrase_repo,
+            gift_repo=self.gift_repo,
+            poster_request_repo=self.poster_request_repo,
+            badge_service=self.badge_service,
+            usage_service=self.usage_service,
+        )
+
+    def _setup(self, *, phrases, long_phrases, posters, gifts, badges_progress, usages):
+        self.phrase_repo.get_phrases.return_value = phrases
+        self.long_phrase_repo.get_phrases.return_value = long_phrases
+        self.poster_request_repo.get_completed_by_user.return_value = posters
+        self.gift_repo.get_gifts_for_user.return_value = gifts
+        self.badge_service.get_all_badges_progress.return_value = badges_progress
+        self.usage_service.get_user_stats.return_value = {"total_usages": usages}
+
+    @pytest.mark.asyncio
+    async def test_aggregates_a_coherent_summary(self, service):
+        earned = _progress("poeta", True)
+        unearned = _progress("vip", False)
+        poster = object()
+        gift = object()
+        self._setup(
+            phrases=[Phrase(id=1, text="cuñado", usages=2)],
+            long_phrases=[LongPhrase(id=2, text="frase larga", usages=9)],
+            posters=[poster],
+            gifts=[gift],
+            badges_progress=[earned, unearned],
+            usages=42,
+        )
+
+        user = User(id="100", platform="telegram", points=250)
+        summary = await service.get_profile_summary(user)
+
+        assert isinstance(summary, ProfileSummary)
+        assert summary.user is user
+        assert summary.points == 250
+        assert summary.stats["total_usages"] == 42
+        assert summary.posters == [poster]
+        assert summary.gifts == [gift]
+        assert summary.badges_progress == [earned, unearned]
+        # Only earned Logros are surfaced as awarded badges.
+        assert [b.id for b in summary.earned_badges] == ["poeta"]
+        # Level grows every 100 Puntos de reputación.
+        assert summary.level == 3
+
+    @pytest.mark.asyncio
+    async def test_pieces_combine_apelativo_and_frase_sorted_by_usage(self, service):
+        self._setup(
+            phrases=[Phrase(id=1, text="a", usages=2)],
+            long_phrases=[LongPhrase(id=2, text="b", usages=9)],
+            posters=[],
+            gifts=[],
+            badges_progress=[],
+            usages=0,
+        )
+
+        user = User(id="100", platform="telegram", points=0)
+        summary = await service.get_profile_summary(user)
+
+        # Apelativo and Frase cuñadil are merged and ordered by usage desc.
+        assert [p.id for p in summary.pieces] == [2, 1]
+        assert summary.pieces_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_id_yields_no_gifts(self, service):
+        self._setup(
+            phrases=[],
+            long_phrases=[],
+            posters=[],
+            gifts=[],
+            badges_progress=[],
+            usages=0,
+        )
+
+        # Slack Perfiles have non-numeric ids; Regalo lookup must not blow up.
+        user = User(id="U123ABC", platform="slack", points=0)
+        summary = await service.get_profile_summary(user)
+
+        assert summary.gifts == []
+        self.gift_repo.get_gifts_for_user.assert_not_called()

--- a/src/services/proposal_service.py
+++ b/src/services/proposal_service.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timedelta
+from enum import Enum
 from typing import TYPE_CHECKING
 from telegram import Update
 from telegram.error import BadRequest, TelegramError
@@ -15,8 +17,34 @@ from core.config import config
 
 if TYPE_CHECKING:
     from services.user_service import UserService
+    from services.phrase_service import PhraseService
 
 logger = logging.getLogger(__name__)
+
+# A Propuesta whose similarity to existing content is above this threshold is
+# treated as a duplicate rather than accepted into the Consejo voting flow.
+SIMILARITY_DISCARD_THRESHOLD = 90
+
+
+class IntakeStatus(Enum):
+    """Outcome of submitting a Propuesta for Consejo evaluation."""
+
+    EMPTY = "empty"
+    DUPLICATE_APPROVED = "duplicate_approved"
+    DUPLICATE_ACTIVE = "duplicate_active"
+    DUPLICATE_REJECTED = "duplicate_rejected"
+    ACCEPTED = "accepted"
+
+
+@dataclass(frozen=True)
+class IntakeResult:
+    """Result of Pieza cuñadil intake, carrying the decision plus any context a
+    caller needs to format a platform response (no platform objects involved)."""
+
+    status: IntakeStatus
+    proposal: Proposal | None = None
+    similar_text: str = ""
+    similarity: int = 0
 
 
 class ProposalService:
@@ -26,13 +54,72 @@ class ProposalService:
         long_repo: LongProposalRepository,
         user_repo: UserRepository,
         user_service: UserService,
+        phrase_service: PhraseService,
     ):
         self.repo = repo
         self.long_repo = long_repo
         self.user_repo = user_repo
         self.user_service = user_service
+        self.phrase_service = phrase_service
         self._curators_cache: dict[str, str] = {}
         self._last_update: datetime | None = None
+
+    async def submit(self, proposal: Proposal) -> IntakeResult:
+        """Run Pieza cuñadil intake for a Propuesta and decide its fate.
+
+        Owns the whole decision: empty text, duplicate against approved Pieza
+        cuñadil, duplicate against an active Propuesta, duplicate against a
+        rejected Propuesta, or acceptance into the Consejo voting flow. The
+        Apelativo vs Frase cuñadil split is derived from the proposal type so
+        callers never pick a repository.
+        """
+        is_long = isinstance(proposal, LongProposal)
+
+        if not proposal.text:
+            return IntakeResult(IntakeStatus.EMPTY)
+
+        (
+            most_similar_phrase,
+            phrase_similarity,
+        ) = await self.phrase_service.find_most_similar(proposal.text, long=is_long)
+        if phrase_similarity > SIMILARITY_DISCARD_THRESHOLD:
+            return IntakeResult(
+                IntakeStatus.DUPLICATE_APPROVED,
+                similar_text=most_similar_phrase.text,
+                similarity=phrase_similarity,
+            )
+
+        (
+            most_similar_proposal,
+            proposal_similarity,
+        ) = await self.find_most_similar_proposal(proposal.text, is_long=is_long)
+        if (
+            proposal_similarity > SIMILARITY_DISCARD_THRESHOLD
+            and most_similar_proposal is not None
+        ):
+            status = (
+                IntakeStatus.DUPLICATE_REJECTED
+                if most_similar_proposal.voting_ended
+                else IntakeStatus.DUPLICATE_ACTIVE
+            )
+            return IntakeResult(
+                status,
+                proposal=most_similar_proposal,
+                similar_text=most_similar_proposal.text,
+                similarity=proposal_similarity,
+            )
+
+        if isinstance(proposal, LongProposal):
+            await self.long_repo.save(proposal)
+        else:
+            await self.repo.save(proposal)
+
+        return IntakeResult(
+            IntakeStatus.ACCEPTED,
+            proposal=proposal,
+            similar_text=most_similar_phrase.text,
+            similarity=phrase_similarity,
+        )
 
     def create_from_update(
         self, update: Update, is_long: bool = False, text: str | None = None

--- a/src/services/proposal_service_test.py
+++ b/src/services/proposal_service_test.py
@@ -13,8 +13,13 @@ class TestProposalService:
         self.long_repo = AsyncMock()
         self.user_repo = AsyncMock()
         self.user_service = AsyncMock()
+        self.phrase_service = AsyncMock()
         return ProposalService(
-            self.repo, self.long_repo, self.user_repo, self.user_service
+            self.repo,
+            self.long_repo,
+            self.user_repo,
+            self.user_service,
+            self.phrase_service,
         )
 
     def test_create_from_update_validation(self, service):
@@ -222,3 +227,122 @@ class TestProposalService:
                 res = await service.reject("LongProposal", "1")
                 assert res is True
                 mock_dismiss.assert_called_once_with(p, mock_bot)
+
+
+class TestProposalIntake:
+    """Pieza cuñadil intake: a single service entry point owns the decision of
+    whether a Propuesta is empty, a duplicate (approved / active / rejected) or
+    accepted. The Apelativo vs Frase cuñadil split is hidden behind the proposal
+    type, so callers do not branch on parallel repositories."""
+
+    @pytest.fixture
+    def service(self):
+        self.repo = AsyncMock()
+        self.long_repo = AsyncMock()
+        self.user_repo = AsyncMock()
+        self.user_service = AsyncMock()
+        self.phrase_service = AsyncMock()
+        return ProposalService(
+            self.repo,
+            self.long_repo,
+            self.user_repo,
+            self.user_service,
+            self.phrase_service,
+        )
+
+    @pytest.mark.asyncio
+    async def test_submit_empty_proposal(self, service):
+        from services.proposal_service import IntakeStatus
+
+        proposal = Proposal(id="1", text="", user_id=10)
+        result = await service.submit(proposal)
+
+        assert result.status is IntakeStatus.EMPTY
+        self.repo.save.assert_not_called()
+        self.long_repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_submit_apelativo_accepted(self, service):
+        from models.phrase import Phrase
+        from services.proposal_service import IntakeStatus
+
+        # No similar approved phrase, no similar proposal.
+        self.phrase_service.find_most_similar.return_value = (Phrase(text="other"), 10)
+        service.find_most_similar_proposal = AsyncMock(return_value=(None, 0))
+
+        proposal = Proposal(id="1", text="cuñado", user_id=10)
+        result = await service.submit(proposal)
+
+        assert result.status is IntakeStatus.ACCEPTED
+        assert result.proposal is proposal
+        # Apelativo is saved through the short repo, not the long repo.
+        self.repo.save.assert_called_once_with(proposal)
+        self.long_repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_submit_frase_accepted_uses_long_repo(self, service):
+        from models.phrase import LongPhrase
+        from services.proposal_service import IntakeStatus
+
+        self.phrase_service.find_most_similar.return_value = (
+            LongPhrase(text="other"),
+            10,
+        )
+        service.find_most_similar_proposal = AsyncMock(return_value=(None, 0))
+
+        proposal = LongProposal(id="1", text="una frase larga cuñadil", user_id=10)
+        result = await service.submit(proposal)
+
+        assert result.status is IntakeStatus.ACCEPTED
+        # The Frase / Apelativo split is decided internally from the proposal type.
+        self.long_repo.save.assert_called_once_with(proposal)
+        self.repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_submit_duplicate_approved(self, service):
+        from models.phrase import Phrase
+        from services.proposal_service import IntakeStatus
+
+        self.phrase_service.find_most_similar.return_value = (
+            Phrase(text="cuñado"),
+            100,
+        )
+        service.find_most_similar_proposal = AsyncMock(return_value=(None, 0))
+
+        proposal = Proposal(id="1", text="cuñado", user_id=10)
+        result = await service.submit(proposal)
+
+        assert result.status is IntakeStatus.DUPLICATE_APPROVED
+        assert result.similar_text == "cuñado"
+        assert result.similarity == 100
+        self.repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_submit_duplicate_active_proposal(self, service):
+        from models.phrase import Phrase
+        from services.proposal_service import IntakeStatus
+
+        self.phrase_service.find_most_similar.return_value = (Phrase(text="x"), 10)
+        existing = Proposal(id="9", text="cuñado", voting_ended=False)
+        service.find_most_similar_proposal = AsyncMock(return_value=(existing, 95))
+
+        proposal = Proposal(id="1", text="cuñado", user_id=10)
+        result = await service.submit(proposal)
+
+        assert result.status is IntakeStatus.DUPLICATE_ACTIVE
+        self.repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_submit_duplicate_rejected_proposal(self, service):
+        from models.phrase import Phrase
+        from services.proposal_service import IntakeStatus
+
+        self.phrase_service.find_most_similar.return_value = (Phrase(text="x"), 10)
+        existing = Proposal(id="9", text="cuñado", voting_ended=True)
+        service.find_most_similar_proposal = AsyncMock(return_value=(existing, 95))
+
+        proposal = Proposal(id="1", text="cuñado", user_id=10)
+        result = await service.submit(proposal)
+
+        assert result.status is IntakeStatus.DUPLICATE_REJECTED
+        self.repo.save.assert_not_called()

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -1,12 +1,10 @@
 import logging
 import secrets
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any
 from telegram import Update
 from models.user import User
 from models.chat import Chat
-from models.phrase import Phrase, LongPhrase
-from models.proposal import Proposal, LongProposal
 from models.link_request import LinkRequest
 
 if TYPE_CHECKING:
@@ -358,32 +356,7 @@ class UserService:
 
         await self.save_user(target_user)
 
-        # Migrate Content Ownership
-        phrases = await self.phrase_repo.get_phrases(user_id=str(source_user.id))
-        for p in phrases:
-            p.user_id = target_user.id
-            await self.phrase_repo.save(cast(Phrase, p))
-
-        long_phrases = await self.long_phrase_repo.get_phrases(
-            user_id=str(source_user.id)
-        )
-        for lp in long_phrases:
-            lp.user_id = target_user.id
-            await self.long_phrase_repo.save(cast(LongPhrase, lp))
-
-        proposals = await self.proposal_repo.get_proposals(
-            user_id=str(source_user.id), limit=1000
-        )
-        for prop in proposals:
-            prop.user_id = target_user.id
-            await self.proposal_repo.save(cast(Proposal, prop))
-
-        long_proposals = await self.long_proposal_repo.get_proposals(
-            user_id=str(source_user.id), limit=1000
-        )
-        for lprop in long_proposals:
-            lprop.user_id = target_user.id
-            await self.long_proposal_repo.save(cast(LongProposal, lprop))
+        await self._migrate_authorship(source_user.id, target_user.id)
 
         # Instead of deleting, we make source_user an alias of target_user
         source_user.linked_to = target_user.id
@@ -395,3 +368,37 @@ class UserService:
         await self.link_request_repo.delete(token)
 
         return True
+
+    async def _migrate_authorship(
+        self, source_id: str | int, target_id: str | int
+    ) -> None:
+        """Reassign every authored thing from an absorbed Cuenta de plataforma
+        to the canonical Perfil.
+
+        This is the single seam for authorship migration: supporting a new
+        authored type (a future Pieza cuñadil kind or Propuesta variant) means
+        adding one entry below, not another loop in ``complete_link``.
+        """
+        source_key = str(source_id)
+        authored: list[tuple[Any, list[Any]]] = [
+            (self.phrase_repo, await self.phrase_repo.get_phrases(user_id=source_key)),
+            (
+                self.long_phrase_repo,
+                await self.long_phrase_repo.get_phrases(user_id=source_key),
+            ),
+            (
+                self.proposal_repo,
+                await self.proposal_repo.get_proposals(user_id=source_key, limit=1000),
+            ),
+            (
+                self.long_proposal_repo,
+                await self.long_proposal_repo.get_proposals(
+                    user_id=source_key, limit=1000
+                ),
+            ),
+        ]
+
+        for repo, items in authored:
+            for item in items:
+                item.user_id = target_id
+                await repo.save(item)

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -20,6 +20,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Upper bound on proposals reassigned per kind during account linking. A Perfil
+# authoring more than this is implausible; if it ever happens we log rather than
+# silently drop the overflow.
+_AUTHORSHIP_MIGRATION_LIMIT = 1000
+
 
 class UserService:
     def __init__(
@@ -380,22 +385,34 @@ class UserService:
         adding one entry below, not another loop in ``complete_link``.
         """
         source_key = str(source_id)
+        proposals = await self.proposal_repo.get_proposals(
+            user_id=source_key, limit=_AUTHORSHIP_MIGRATION_LIMIT
+        )
+        long_proposals = await self.long_proposal_repo.get_proposals(
+            user_id=source_key, limit=_AUTHORSHIP_MIGRATION_LIMIT
+        )
+        for kind, items in (
+            ("proposals", proposals),
+            ("long_proposals", long_proposals),
+        ):
+            if len(items) >= _AUTHORSHIP_MIGRATION_LIMIT:
+                logger.warning(
+                    "Authorship migration hit the %d-item cap for %s authored by %s; "
+                    "older items were not reassigned to %s.",
+                    _AUTHORSHIP_MIGRATION_LIMIT,
+                    kind,
+                    source_key,
+                    target_id,
+                )
+
         authored: list[tuple[Any, list[Any]]] = [
             (self.phrase_repo, await self.phrase_repo.get_phrases(user_id=source_key)),
             (
                 self.long_phrase_repo,
                 await self.long_phrase_repo.get_phrases(user_id=source_key),
             ),
-            (
-                self.proposal_repo,
-                await self.proposal_repo.get_proposals(user_id=source_key, limit=1000),
-            ),
-            (
-                self.long_proposal_repo,
-                await self.long_proposal_repo.get_proposals(
-                    user_id=source_key, limit=1000
-                ),
-            ),
+            (self.proposal_repo, proposals),
+            (self.long_proposal_repo, long_proposals),
         ]
 
         for repo, items in authored:

--- a/src/services/user_service_link_test.py
+++ b/src/services/user_service_link_test.py
@@ -199,3 +199,63 @@ async def test_complete_link_same_user(mock_repos):
 
     success = await service.complete_link(token, "u1", "telegram")
     assert success is False
+
+
+@pytest.mark.asyncio
+async def test_complete_link_migrates_all_authored_content(mock_repos):
+    """Linking must move authorship of every authored thing (Apelativo, Frase
+    cuñadil and both kinds of Propuesta) from the absorbed Cuenta de plataforma
+    to the canonical Perfil through a single migration seam."""
+    (
+        user_repo,
+        link_repo,
+        phrase_repo,
+        long_phrase_repo,
+        proposal_repo,
+        long_proposal_repo,
+        chat_repo,
+    ) = mock_repos
+    service = UserService(
+        user_repo=user_repo,
+        link_request_repo=link_repo,
+        chat_repo=chat_repo,
+        phrase_repo=phrase_repo,
+        long_phrase_repo=long_phrase_repo,
+        proposal_repo=proposal_repo,
+        long_proposal_repo=long_proposal_repo,
+    )
+
+    token = "ABCDEF"
+    source_user = User(id="source", platform="telegram")
+    target_user = User(id="target", platform="slack")
+    link_repo.load.return_value = LinkRequest(
+        token=token, source_user_id="source", source_platform="telegram"
+    )
+
+    def load_side_effect(uid, follow_link=True):
+        return {"source": source_user, "target": target_user}.get(uid)
+
+    user_repo.load.side_effect = load_side_effect
+    user_repo.load_raw.side_effect = lambda uid: load_side_effect(uid)
+
+    apelativo = MagicMock()
+    frase = MagicMock()
+    propuesta = MagicMock()
+    propuesta_larga = MagicMock()
+    phrase_repo.get_phrases.return_value = [apelativo]
+    long_phrase_repo.get_phrases.return_value = [frase]
+    proposal_repo.get_proposals.return_value = [propuesta]
+    long_proposal_repo.get_proposals.return_value = [propuesta_larga]
+
+    success = await service.complete_link(token, "target", "slack")
+
+    assert success is True
+    # Every authored thing now points at the canonical Perfil and was persisted.
+    assert apelativo.user_id == "target"
+    assert frase.user_id == "target"
+    assert propuesta.user_id == "target"
+    assert propuesta_larga.user_id == "target"
+    phrase_repo.save.assert_called_with(apelativo)
+    long_phrase_repo.save.assert_called_with(frase)
+    proposal_repo.save.assert_called_with(propuesta)
+    long_proposal_repo.save.assert_called_with(propuesta_larga)

--- a/src/slack/handlers/bolt_listeners.py
+++ b/src/slack/handlers/bolt_listeners.py
@@ -533,29 +533,24 @@ def register_listeners(app: AsyncApp) -> None:
         event = body["event"]
         text = event.get("text", "")
 
-        response = await services.cunhao_agent.answer(text)
-        await services.usage_service.log_usage(
-            user_id=event.get("user"),
-            platform="slack",
-            action=ActionType.AI_ASK,
+        reply = await services.chat_interaction_service.answer(
+            user_id=event.get("user"), platform="slack", text=text
         )
-        await say(response, thread_ts=event.get("ts"))
+        await say(reply.text, thread_ts=event.get("ts"))
 
         try:
-            reaction_unicode = await services.ai_service.analyze_sentiment_and_react(
-                text
-            )
-            if reaction_unicode and reaction_unicode in EMOJI_MAP:
+            decision = await services.chat_interaction_service.decide_reaction(text)
+            if decision.emoji and decision.emoji in EMOJI_MAP:
                 await client.reactions_add(
-                    name=EMOJI_MAP[reaction_unicode],
+                    name=EMOJI_MAP[decision.emoji],
                     channel=event.get("channel"),
                     timestamp=event.get("ts"),
                 )
 
-                reaction_badges = await services.usage_service.log_usage(
-                    user_id=event.get("user"),
-                    platform="slack",
-                    action=ActionType.REACTION_RECEIVED,
+                reaction_badges = (
+                    await services.chat_interaction_service.record_reaction_received(
+                        user_id=event.get("user"), platform="slack"
+                    )
                 )
                 await notify_new_badges_slack(say, reaction_badges)
         except Exception as e:
@@ -578,30 +573,23 @@ def register_listeners(app: AsyncApp) -> None:
         is_mentioned = bot_user_id and f"<@{bot_user_id}>" in text
 
         if channel_type == "im" and "subtype" not in event:
-            response = await services.cunhao_agent.answer(text)
-            await services.usage_service.log_usage(
-                user_id=event.get("user"),
-                platform="slack",
-                action=ActionType.AI_ASK,
+            reply = await services.chat_interaction_service.answer(
+                user_id=event.get("user"), platform="slack", text=text
             )
-            await say(response)
+            await say(reply.text)
 
         if not is_mentioned:
             try:
-                reaction_unicode = (
-                    await services.ai_service.analyze_sentiment_and_react(text)
-                )
-                if reaction_unicode and reaction_unicode in EMOJI_MAP:
+                decision = await services.chat_interaction_service.decide_reaction(text)
+                if decision.emoji and decision.emoji in EMOJI_MAP:
                     await client.reactions_add(
-                        name=EMOJI_MAP[reaction_unicode],
+                        name=EMOJI_MAP[decision.emoji],
                         channel=event.get("channel"),
                         timestamp=event.get("ts"),
                     )
 
-                    reaction_badges = await services.usage_service.log_usage(
-                        user_id=event.get("user"),
-                        platform="slack",
-                        action=ActionType.REACTION_RECEIVED,
+                    reaction_badges = await services.chat_interaction_service.record_reaction_received(
+                        user_id=event.get("user"), platform="slack"
                     )
                     await notify_new_badges_slack(say, reaction_badges)
             except Exception as e:

--- a/src/tg/handlers/commands/profile.py
+++ b/src/tg/handlers/commands/profile.py
@@ -42,20 +42,14 @@ async def handle_profile(update: Update, context: CallbackContext) -> None:
         )
         await notify_new_badges(update, context, new_badges)
 
-        stats = await services.usage_service.get_user_stats(user_id, platform)
-        all_badges_progress = await services.badge_service.get_all_badges_progress(
-            user_id, platform
-        )
+        # Same coherent Perfil summary the web profile uses.
+        summary = await services.profile_service.get_profile_summary(user)
 
-        earned_list: list[str] = []
-
-        for p in all_badges_progress:
-            badge = p.badge
-            if p.is_earned:
-                earned_list.append(
-                    f"{badge.icon} <b>{html.escape(badge.name)}</b>\n"
-                    f"<i>{html.escape(badge.description)}</i>"
-                )
+        earned_list: list[str] = [
+            f"{badge.icon} <b>{html.escape(badge.name)}</b>\n"
+            f"<i>{html.escape(badge.description)}</i>"
+            for badge in summary.earned_badges
+        ]
 
         badges_text = ""
         if earned_list:
@@ -69,8 +63,8 @@ async def handle_profile(update: Update, context: CallbackContext) -> None:
             f"🔗 <a href='{profile_url}'>Ver perfil en la web</a>\n\n"
             f"👤 <b>Perfil de {user_name}</b>\n"
             f"━━━━━━━━━━━━━━━\n"
-            f"🏆 <b>Puntos:</b> {user.points}\n"
-            f"📊 <b>Usos totales:</b> {stats['total_usages']}\n"
+            f"🏆 <b>Puntos:</b> {summary.points}\n"
+            f"📊 <b>Usos totales:</b> {summary.stats['total_usages']}\n"
             f"🎖️ <b>Logros conseguidos:</b> {badges_text}"
         )
 

--- a/src/tg/handlers/commands/profile_test.py
+++ b/src/tg/handlers/commands/profile_test.py
@@ -58,18 +58,17 @@ async def test_handle_profile_success(mock_container):
         mock_container["user_service"].get_user.return_value = user
 
         mock_container["usage_service"].log_usage.return_value = []
-        mock_container["usage_service"].get_user_stats.return_value = {
-            "total_usages": 10
-        }
 
-        badge_progress = MagicMock()
-        badge_progress.is_earned = True
-        badge_progress.badge.name = "Madrugador"
-        badge_progress.badge.icon = "🌅"
-        badge_progress.badge.description = "Test"
-        mock_container["badge_service"].get_all_badges_progress.return_value = [
-            badge_progress
-        ]
+        # The handler consumes one coherent Perfil summary from ProfileService.
+        badge = MagicMock()
+        badge.name = "Madrugador"
+        badge.icon = "🌅"
+        badge.description = "Test"
+        summary = MagicMock()
+        summary.points = 500
+        summary.stats = {"total_usages": 10}
+        summary.earned_badges = [badge]
+        mock_container["profile_service"].get_profile_summary.return_value = summary
 
         mock_config.base_url = "http://test.com"
 

--- a/src/tg/handlers/commands/submit.py
+++ b/src/tg/handlers/commands/submit.py
@@ -5,19 +5,18 @@ from models.phrase import LongPhrase, Phrase
 from models.proposal import LongProposal, Proposal
 from core.container import services
 from models.usage import ActionType
+from services.proposal_service import IntakeStatus
 from tg.decorators import log_update
 from tg.markup.keyboards import build_vote_keyboard
 from tg.utils.badges import notify_new_badges
 from core.config import config
-
-SIMILARITY_DISCARD_THRESHOLD = 90
 
 
 async def _notify_proposal_to_curators(
     bot: Bot,
     proposal: Proposal | LongProposal,
     submitted_by: str,
-    most_similar: Phrase | LongPhrase,
+    most_similar_text: str,
     similarity_ratio: int,
 ) -> None:
     curators_reply_markup = InlineKeyboardMarkup(
@@ -34,7 +33,7 @@ async def _notify_proposal_to_curators(
     curators_message_text = (
         f"{submitted_by} dice que deberiamos añadir la siguiente {name} a la lista:"
         f"\n'*{proposal.text}*'"
-        f"\n\nLa mas parecida es: '*{most_similar.text}*' ({similarity_ratio}%)."
+        f"\n\nLa mas parecida es: '*{most_similar_text}*' ({similarity_ratio}%)."
     )
 
     await bot.send_message(
@@ -61,10 +60,14 @@ async def submit_handling(
         update, is_long=is_long, text=text
     )
 
-    # Determinar modelos y repositorios según el tipo
+    # Determinar nombre del tipo de frase para los mensajes
     name = LongPhrase.display_name if is_long else Phrase.display_name
 
-    if not proposal.text:
+    # The Pieza cuñadil intake module owns the decision; the handler only
+    # translates the outcome into a Telegram response.
+    result = await services.proposal_service.submit(proposal)
+
+    if result.status is IntakeStatus.EMPTY:
         random_phrase = (await services.phrase_service.get_random()).text
         return await update.effective_message.reply_text(
             f"¿Qué *{name}* quieres proponer, {random_phrase}?\n"
@@ -73,54 +76,31 @@ async def submit_handling(
             parse_mode=constants.ParseMode.MARKDOWN,
         )
 
-    # Fuzzy search phrases
-    (
-        most_similar_phrase,
-        phrase_similarity,
-    ) = await services.phrase_service.find_most_similar(proposal.text, long=is_long)
-
-    if phrase_similarity > SIMILARITY_DISCARD_THRESHOLD:
+    if result.status is IntakeStatus.DUPLICATE_APPROVED:
         p_random = (await services.phrase_service.get_random()).text
         msg = f"Esa ya la tengo aprobada y en la lista, {p_random}."
-        if phrase_similarity != 100:
-            msg += f"\nSe parece demasiado a: '*{most_similar_phrase.text}*'"
-
+        if result.similarity != 100:
+            msg += f"\nSe parece demasiado a: '*{result.similar_text}*'"
         return await update.effective_message.reply_text(
             msg, parse_mode=constants.ParseMode.MARKDOWN
         )
 
-    # Fuzzy search proposals
-    (
-        most_similar_proposal,
-        proposal_similarity,
-    ) = await services.proposal_service.find_most_similar_proposal(
-        proposal.text, is_long=is_long
-    )
-
-    if proposal_similarity > SIMILARITY_DISCARD_THRESHOLD and most_similar_proposal:
+    if result.status is IntakeStatus.DUPLICATE_REJECTED:
         p_random = (await services.phrase_service.get_random()).text
-        if most_similar_proposal.voting_ended:
-            # Proposal existed and voting ended. Since phrase check passed (didn't exist), it must be rejected.
-            return await update.effective_message.reply_text(
-                f"Esa propuesta ya pasó por el consejo y fue rechazada, lo siento {p_random}.",
-                parse_mode=constants.ParseMode.MARKDOWN,
-            )
-        else:
-            # Proposal exists and voting is active
-            return await update.effective_message.reply_text(
-                f"Esa frase ya ha sido propuesta y está siendo votada ahora mismo, ten paciencia {p_random}.",
-                parse_mode=constants.ParseMode.MARKDOWN,
-            )
+        return await update.effective_message.reply_text(
+            f"Esa propuesta ya pasó por el consejo y fue rechazada, lo siento {p_random}.",
+            parse_mode=constants.ParseMode.MARKDOWN,
+        )
 
-    if is_long:
-        if isinstance(proposal, LongProposal):
-            await services.long_proposal_repo.save(proposal)
-    else:
-        if isinstance(proposal, Proposal):
-            await services.proposal_repo.save(proposal)
+    if result.status is IntakeStatus.DUPLICATE_ACTIVE:
+        p_random = (await services.phrase_service.get_random()).text
+        return await update.effective_message.reply_text(
+            f"Esa frase ya ha sido propuesta y está siendo votada ahora mismo, ten paciencia {p_random}.",
+            parse_mode=constants.ParseMode.MARKDOWN,
+        )
 
     await _notify_proposal_to_curators(
-        bot, proposal, submitted_by, most_similar_phrase, phrase_similarity
+        bot, proposal, submitted_by, result.similar_text, result.similarity
     )
 
     # Log usage and check for badges

--- a/src/tg/handlers/commands/submit_test.py
+++ b/src/tg/handlers/commands/submit_test.py
@@ -4,8 +4,8 @@ from tg.handlers.commands.submit import (
     handle_submit,
     submit_handling,
 )
-from models.phrase import Phrase
 from models.proposal import Proposal
+from services.proposal_service import IntakeResult, IntakeStatus
 
 
 @pytest.fixture
@@ -13,14 +13,11 @@ def mock_services():
     with patch("tg.handlers.commands.submit.services") as ms:
         ms.phrase_service.get_random = AsyncMock()
         ms.phrase_service.get_random.return_value.text = "cuñao"
-        ms.phrase_service.find_most_similar = AsyncMock()
-        ms.proposal_service.find_most_similar_proposal = AsyncMock(
-            return_value=(None, 0)
-        )
+        # The deepened intake module owns the decision; the handler only
+        # translates the IntakeResult it returns.
+        ms.proposal_service.submit = AsyncMock()
         ms.usage_service.log_usage = AsyncMock(return_value=[])
         ms.user_service.update_or_create_user = AsyncMock()
-        ms.proposal_repo.save = AsyncMock()
-        ms.long_proposal_repo.save = AsyncMock()
         yield ms
 
 
@@ -51,11 +48,9 @@ async def test_handle_submit_success(mock_services):
 
     mock_proposal = Proposal(text="test", id="1")
     mock_services.proposal_service.create_from_update.return_value = mock_proposal
-    mock_services.phrase_service.find_most_similar.return_value = (
-        Phrase(text="sim"),
-        50,
+    mock_services.proposal_service.submit.return_value = IntakeResult(
+        IntakeStatus.ACCEPTED, proposal=mock_proposal, similar_text="sim", similarity=50
     )
-    mock_services.proposal_service.find_most_similar_proposal.return_value = (None, 0)
 
     context = MagicMock()
     context.bot.send_message = AsyncMock()
@@ -64,8 +59,8 @@ async def test_handle_submit_success(mock_services):
         mock_config.mod_chat_id = 123
         await handle_submit(update, context)
 
-    mock_services.proposal_repo.save.assert_called_once_with(mock_proposal)
-    update.effective_message.reply_text.assert_called_once()
+    # Accepted proposals are forwarded to the Consejo and the proposer is thanked.
+    context.bot.send_message.assert_called_once()
     assert (
         "Tu aportación será valorada"
         in update.effective_message.reply_text.call_args[0][0]
@@ -79,24 +74,19 @@ async def test_handle_submit_duplicate_phrase(mock_services):
     update.effective_user.name = "Test"
     update.effective_user.username = "testuser"
     update.effective_message.chat.type = "private"
-    update.effective_message.chat.title = "Chat"
-    update.effective_message.chat.username = "testchat"
     update.effective_message.chat_id = 123
     update.effective_message.text = "/proponer test"
     update.effective_message.reply_text = AsyncMock()
 
     mock_proposal = Proposal(text="test", id="1")
     mock_services.proposal_service.create_from_update.return_value = mock_proposal
-    # Similarity > 90
-    mock_services.phrase_service.find_most_similar.return_value = (
-        Phrase(text="test"),
-        95,
+    mock_services.proposal_service.submit.return_value = IntakeResult(
+        IntakeStatus.DUPLICATE_APPROVED, similar_text="test", similarity=95
     )
 
     context = MagicMock()
     await handle_submit(update, context)
 
-    mock_services.proposal_repo.save.assert_not_called()
     msg = update.effective_message.reply_text.call_args[0][0]
     assert "Esa ya la tengo aprobada" in msg
     assert "Se parece demasiado" in msg
@@ -109,30 +99,20 @@ async def test_handle_submit_duplicate_proposal_voting_active(mock_services):
     update.effective_user.name = "Test"
     update.effective_user.username = "testuser"
     update.effective_message.chat.type = "private"
-    update.effective_message.chat.title = "Chat"
-    update.effective_message.chat.username = "testchat"
     update.effective_message.chat_id = 123
     update.effective_message.text = "/proponer test"
     update.effective_message.reply_text = AsyncMock()
 
     mock_proposal = Proposal(text="test", id="1")
     mock_services.proposal_service.create_from_update.return_value = mock_proposal
-    mock_services.phrase_service.find_most_similar.return_value = (
-        Phrase(text="sim"),
-        50,
-    )
-
-    # Similar proposal, voting active
     existing_proposal = Proposal(text="test", id="2", voting_ended=False)
-    mock_services.proposal_service.find_most_similar_proposal.return_value = (
-        existing_proposal,
-        95,
+    mock_services.proposal_service.submit.return_value = IntakeResult(
+        IntakeStatus.DUPLICATE_ACTIVE, proposal=existing_proposal, similarity=95
     )
 
     context = MagicMock()
     await handle_submit(update, context)
 
-    mock_services.proposal_repo.save.assert_not_called()
     msg = update.effective_message.reply_text.call_args[0][0]
     assert "está siendo votada ahora mismo" in msg
 
@@ -144,30 +124,20 @@ async def test_handle_submit_duplicate_proposal_rejected(mock_services):
     update.effective_user.name = "Test"
     update.effective_user.username = "testuser"
     update.effective_message.chat.type = "private"
-    update.effective_message.chat.title = "Chat"
-    update.effective_message.chat.username = "testchat"
     update.effective_message.chat_id = 123
     update.effective_message.text = "/proponer test"
     update.effective_message.reply_text = AsyncMock()
 
     mock_proposal = Proposal(text="test", id="1")
     mock_services.proposal_service.create_from_update.return_value = mock_proposal
-    mock_services.phrase_service.find_most_similar.return_value = (
-        Phrase(text="sim"),
-        50,
-    )
-
-    # Similar proposal, voting ended
     existing_proposal = Proposal(text="test", id="2", voting_ended=True)
-    mock_services.proposal_service.find_most_similar_proposal.return_value = (
-        existing_proposal,
-        95,
+    mock_services.proposal_service.submit.return_value = IntakeResult(
+        IntakeStatus.DUPLICATE_REJECTED, proposal=existing_proposal, similarity=95
     )
 
     context = MagicMock()
     await handle_submit(update, context)
 
-    mock_services.proposal_repo.save.assert_not_called()
     msg = update.effective_message.reply_text.call_args[0][0]
     assert "fue rechazada" in msg
 
@@ -179,8 +149,6 @@ async def test_handle_submit_too_long(mock_services):
     update.effective_user.name = "Test"
     update.effective_user.username = "testuser"
     update.effective_message.chat.type = "private"
-    update.effective_message.chat.title = "Chat"
-    update.effective_message.chat.username = "testchat"
     update.effective_message.chat_id = 123
     update.effective_message.text = "/proponer one two three four five six"
     update.effective_message.reply_text = AsyncMock()
@@ -188,7 +156,8 @@ async def test_handle_submit_too_long(mock_services):
     context = MagicMock()
     await handle_submit(update, context)
 
-    mock_services.proposal_repo.save.assert_not_called()
+    # Too-long short proposals are short-circuited before intake runs.
+    mock_services.proposal_service.submit.assert_not_called()
     update.effective_message.reply_text.assert_called_once()
     assert (
         "Mejor prueba con /proponerfrase"
@@ -203,19 +172,18 @@ async def test_handle_submit_empty(mock_services):
     update.effective_user.name = "Test"
     update.effective_user.username = "testuser"
     update.effective_message.chat.type = "private"
-    update.effective_message.chat.title = "Chat"
-    update.effective_message.chat.username = "testchat"
     update.effective_message.chat_id = 123
     update.effective_message.text = "/proponer"
     update.effective_message.reply_text = AsyncMock()
 
     mock_proposal = Proposal(text="", id="1")
     mock_services.proposal_service.create_from_update.return_value = mock_proposal
+    mock_services.proposal_service.submit.return_value = IntakeResult(
+        IntakeStatus.EMPTY
+    )
 
     context = MagicMock()
-
     await handle_submit(update, context)
 
-    mock_services.proposal_repo.save.assert_not_called()
     update.effective_message.reply_text.assert_called_once()
     assert "quieres proponer" in update.effective_message.reply_text.call_args[0][0]

--- a/src/tg/handlers/messages/text_message.py
+++ b/src/tg/handlers/messages/text_message.py
@@ -2,7 +2,6 @@ import logging
 from telegram import Update, ReactionTypeEmoji
 from telegram.ext import CallbackContext
 from core.container import services
-from models.usage import ActionType
 from tg.decorators import log_update
 from tg.utils.badges import notify_new_badges
 
@@ -44,7 +43,7 @@ async def handle_message(update: Update, context: CallbackContext) -> None:
             )
             return
 
-        # Use AI Agent
+        # Use shared Chat interaction behavior (AI answer + AI_ASK Uso).
         clean_text = message.text
         if is_mentioned and bot_username:
             # Basic cleanup of the mention handle
@@ -54,29 +53,30 @@ async def handle_message(update: Update, context: CallbackContext) -> None:
         # Indicate typing status
         await message.chat.send_action(action="typing")
 
-        response = await services.cunhao_agent.answer(clean_text)
-        new_badges = await services.usage_service.log_usage(
-            user_id=message.from_user.id if message.from_user else "unknown",
-            platform="telegram",
-            action=ActionType.AI_ASK,
+        user_id = message.from_user.id if message.from_user else "unknown"
+        reply = await services.chat_interaction_service.answer(
+            user_id=user_id, platform="telegram", text=clean_text
         )
-        await message.reply_text(response, do_quote=True)
-        await notify_new_badges(update, context, new_badges)
+        await message.reply_text(reply.text, do_quote=True)
+        await notify_new_badges(update, context, reply.new_badges)
 
     # Smart Reaction (runs for EVERY message) - ONLY PREMIUM
     if is_premium:
         try:
-            reaction_emoji = await services.ai_service.analyze_sentiment_and_react(
+            decision = await services.chat_interaction_service.decide_reaction(
                 message.text
             )
-            if reaction_emoji:
-                await message.set_reaction(reaction=ReactionTypeEmoji(reaction_emoji))
+            if decision.emoji:
+                await message.set_reaction(reaction=ReactionTypeEmoji(decision.emoji))
 
-                # Log usage for "Centro de Atención" badge
-                reaction_badges = await services.usage_service.log_usage(
-                    user_id=message.from_user.id if message.from_user else "unknown",
-                    platform="telegram",
-                    action=ActionType.REACTION_RECEIVED,
+                # A delivered reaction is a REACTION_RECEIVED Uso.
+                reaction_badges = (
+                    await services.chat_interaction_service.record_reaction_received(
+                        user_id=message.from_user.id
+                        if message.from_user
+                        else "unknown",
+                        platform="telegram",
+                    )
                 )
                 await notify_new_badges(update, context, reaction_badges)
         except Exception as e:

--- a/src/tg/handlers/messages/text_message_test.py
+++ b/src/tg/handlers/messages/text_message_test.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock, AsyncMock
 from telegram import ReactionTypeEmoji
 from tg.handlers.messages.text_message import handle_message
+from services.chat_interaction_service import AIReply, ReactionDecision
 
 
 @pytest.mark.asyncio
@@ -42,22 +43,24 @@ async def test_handle_message_mention_trigger(mock_container):
     mock_chat = MagicMock()
     mock_chat.is_premium = True
     mock_container["chat_repo"].load = AsyncMock(return_value=mock_chat)
-    mock_container["cunhao_agent"].answer.return_value = "AI Response"
-    mock_container["usage_service"].log_usage.return_value = []
-    mock_container["ai_service"].analyze_sentiment_and_react.return_value = "🍺"
+
+    cis = mock_container["chat_interaction_service"]
+    cis.answer.return_value = AIReply(text="AI Response", new_badges=[])
+    cis.decide_reaction.return_value = ReactionDecision(emoji="🍺")
+    cis.record_reaction_received.return_value = []
 
     await handle_message(update, context)
 
-    mock_container["cunhao_agent"].answer.assert_called_once()
+    # Mention strips the bot handle before asking the shared interaction module.
+    cis.answer.assert_awaited_once_with(user_id=123, platform="telegram", text="Hola")
     update.effective_message.reply_text.assert_called_once_with(
         "AI Response", do_quote=True
     )
-    mock_container["ai_service"].analyze_sentiment_and_react.assert_called_once_with(
-        "Hola @TestBot"
-    )
+    cis.decide_reaction.assert_awaited_once_with("Hola @TestBot")
     update.effective_message.set_reaction.assert_called_once_with(
         reaction=ReactionTypeEmoji("🍺")
     )
+    cis.record_reaction_received.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -90,18 +93,17 @@ async def test_handle_message_no_trigger_only_reaction(mock_container):
     mock_chat = MagicMock()
     mock_chat.is_premium = True
     mock_container["chat_repo"].load = AsyncMock(return_value=mock_chat)
-    mock_container["ai_service"].analyze_sentiment_and_react.return_value = "🇪🇸"
+
+    cis = mock_container["chat_interaction_service"]
+    cis.decide_reaction.return_value = ReactionDecision(emoji="🇪🇸")
+    cis.record_reaction_received.return_value = []
 
     await handle_message(update, context)
 
-    # Should NOT answer
-    mock_container["cunhao_agent"].answer.assert_not_called()
+    # No direct interaction: no AI answer, but a smart reaction still applies.
+    cis.answer.assert_not_called()
     update.effective_message.reply_text.assert_not_called()
-
-    # Should react
-    mock_container["ai_service"].analyze_sentiment_and_react.assert_called_once_with(
-        "Solo un mensaje en el grupo"
-    )
+    cis.decide_reaction.assert_awaited_once_with("Solo un mensaje en el grupo")
     update.effective_message.set_reaction.assert_called_once_with(
         reaction=ReactionTypeEmoji("🇪🇸")
     )

--- a/src/tg/handlers/payments/checkout.py
+++ b/src/tg/handlers/payments/checkout.py
@@ -1,13 +1,20 @@
 import logging
 from datetime import datetime, timedelta, timezone
-from telegram import Update
+from telegram import Message, Update, User
 from telegram.ext import CallbackContext
 from telegram.error import TelegramError
 
 from core.container import services
 from models.usage import ActionType
 from models.chat import Chat
-from models.gift import Gift, GiftType, GIFT_PRICES, GIFT_NAMES
+from models.gift import Gift, GIFT_PRICES, GIFT_NAMES
+from services.payment import (
+    GiftPayment,
+    InvalidPaymentPayload,
+    PosterPayment,
+    SubscriptionPayment,
+    parse_payment_payload,
+)
 from tg.decorators import log_update
 from tg.utils.badges import notify_new_badges
 
@@ -26,217 +33,244 @@ async def handle_pre_checkout(update: Update, context: CallbackContext) -> None:
         await query.answer(ok=False, error_message="Error: Payload vacío.")
         return
 
-    if payload.startswith("subs_month_") or payload.startswith("gift:"):
-        await query.answer(ok=True)
-        return
-
-    # Verify if we have the request data
-    request_data = await services.poster_request_repo.load(payload)
-    if not request_data:
-        # Fallback for old payloads (plain text phrases) or lost data
-        pass
-
     await query.answer(ok=True)
 
 
 @log_update
 async def handle_successful_payment(update: Update, context: CallbackContext) -> None:
-    """Handles the successful payment and delivers the product (image)."""
+    """Handles a successful payment and routes to the right paid fulfillment.
+
+    Payload parsing is delegated to ``services.payment`` so this handler only
+    decides which product (Regalo, Suscripción Premium or Póster) to fulfill.
+    """
     message = update.effective_message
     if not message or not message.successful_payment:
         return
 
     payload = message.successful_payment.invoice_payload
-    telegram_payment_charge_id = message.successful_payment.telegram_payment_charge_id
+    charge_id = message.successful_payment.telegram_payment_charge_id
     user = message.from_user
     if not user:
         return
 
-    if payload.startswith("gift:"):
-        try:
-            # Payload format: gift:chat_id:receiver_id:gift_type
-            parts = payload.split(":")
-            # Handle potential backward compatibility or just parse
-            if len(parts) == 4:
-                _, chat_id_str, receiver_id_str, gift_type_str = parts
-                target_chat_id = int(chat_id_str)
+    try:
+        parsed = parse_payment_payload(payload)
+    except InvalidPaymentPayload as exc:
+        logger.error(f"Unparseable payment payload {payload!r}: {exc}")
+        await context.bot.send_message(
+            chat_id=message.chat_id,
+            text="Hubo un error procesando el pago. Contacta con soporte.",
+        )
+        return
+
+    if isinstance(parsed, GiftPayment):
+        await _fulfill_gift(update, context, message, parsed, user, charge_id)
+    elif isinstance(parsed, SubscriptionPayment):
+        await _fulfill_subscription(update, context, message, parsed, user)
+    else:
+        await _fulfill_poster(update, context, message, parsed, user, charge_id)
+
+
+async def _fulfill_gift(
+    update: Update,
+    context: CallbackContext,
+    message: Message,
+    gift_payment: GiftPayment,
+    user: User,
+    charge_id: str,
+) -> None:
+    """Delivers a Regalo to the receiver Perfil within the Chat."""
+    receiver_id = gift_payment.receiver_id
+    gift_type = gift_payment.gift_type
+    target_chat_id = (
+        gift_payment.chat_id if gift_payment.chat_id is not None else message.chat_id
+    )
+
+    try:
+        gift = Gift(
+            sender_id=user.id,
+            sender_name=user.first_name,
+            receiver_id=receiver_id,
+            gift_type=gift_type,
+            cost=GIFT_PRICES[gift_type],
+        )
+        await services.gift_repo.save(gift)
+
+        # Get receiver name for the message
+        receiver_user = await services.user_repo.load(receiver_id)
+
+        receiver_display_name = "el chaval"
+        if receiver_user:
+            if receiver_user.username:
+                receiver_display_name = f"@{receiver_user.username}"
             else:
-                # Fallback for old payloads
-                _, receiver_id_str, gift_type_str = parts
-                target_chat_id = message.chat_id
+                receiver_display_name = receiver_user.name
 
-            receiver_id = int(receiver_id_str)
-            gift_type = GiftType(gift_type_str)
+        # Notify sender/group
+        caption = (
+            f"¡Toma ya! 🎁\n\n"
+            f"<b>{user.first_name}</b> le ha invitado a un <b>{GIFT_NAMES[gift_type]}</b> a {receiver_display_name}.\n"
+            f"¡Eso sí que es tener clase!\n\n"
+            f"<i>Consérvalo en tu /perfil como oro en paño.</i>"
+        )
 
-            # Save gift
-            gift = Gift(
-                sender_id=user.id,
-                sender_name=user.first_name,
-                receiver_id=receiver_id,
-                gift_type=gift_type,
-                cost=GIFT_PRICES[gift_type],
-            )
-            await services.gift_repo.save(gift)
-
-            # Get receiver name for the message
-            receiver_user = await services.user_repo.load(receiver_id)
-
-            receiver_display_name = "el chaval"
-            if receiver_user:
-                if receiver_user.username:
-                    receiver_display_name = f"@{receiver_user.username}"
-                else:
-                    receiver_display_name = receiver_user.name
-
-            # Notify sender/group
-            caption = (
-                f"¡Toma ya! 🎁\n\n"
-                f"<b>{user.first_name}</b> le ha invitado a un <b>{GIFT_NAMES[gift_type]}</b> a {receiver_display_name}.\n"
-                f"¡Eso sí que es tener clase!\n\n"
-                f"<i>Consérvalo en tu /perfil como oro en paño.</i>"
-            )
-
-            image_path = f"src/static/gifts/{gift_type.value}.png"
-            try:
-                with open(image_path, "rb") as photo:
-                    await context.bot.send_photo(
-                        chat_id=target_chat_id,
-                        photo=photo,
-                        caption=caption,
-                        parse_mode="HTML",
-                    )
-            except Exception as e:
-                logger.error(f"Error sending gift image {image_path}: {e}")
-                await context.bot.send_message(
+        image_path = f"src/static/gifts/{gift_type.value}.png"
+        try:
+            with open(image_path, "rb") as photo:
+                await context.bot.send_photo(
                     chat_id=target_chat_id,
-                    text=caption,
+                    photo=photo,
+                    caption=caption,
                     parse_mode="HTML",
                 )
-
-            # Check if we need to notify privately (if user is not in the group)
-            if target_chat_id != receiver_id:
-                should_notify_private = False
-                try:
-                    member = await context.bot.get_chat_member(
-                        target_chat_id, receiver_id
-                    )
-                    if member.status in ["left", "kicked"]:
-                        should_notify_private = True
-                except TelegramError:
-                    # Likely user not in chat or chat is private/unknown to bot
-                    should_notify_private = True
-
-                if should_notify_private:
-                    try:
-                        private_caption = (
-                            f"¡Sorpresa! 🎁\n\n"
-                            f"<b>{user.first_name}</b> te ha enviado un <b>{GIFT_NAMES[gift_type]}</b> desde el grupo.\n"
-                            f"Como no te he visto por la barra, te lo traigo aquí.\n\n"
-                            f"<i>Lo tienes guardado en tu /perfil.</i>"
-                        )
-                        with open(image_path, "rb") as photo:
-                            await context.bot.send_photo(
-                                chat_id=receiver_id,
-                                photo=photo,
-                                caption=private_caption,
-                                parse_mode="HTML",
-                            )
-                    except Exception as e:
-                        logger.warning(
-                            f"Could not send private gift notification to {receiver_id}: {e}"
-                        )
-
-            # Log usage (GIFT_SENT) for sender
-            new_badges_sender = await services.usage_service.log_usage(
-                user_id=user.id,
-                platform="telegram",
-                action=ActionType.GIFT_SENT,
-                metadata={"gift_type": gift_type, "receiver_id": receiver_id},
-            )
-
-            # Log usage (GIFT_RECEIVED) for receiver
-            new_badges_receiver = await services.usage_service.log_usage(
-                user_id=receiver_id,
-                platform="telegram",
-                action=ActionType.GIFT_RECEIVED,
-                metadata={"gift_type": gift_type, "sender_id": user.id},
-            )
-
-            # Notify badges for sender
-            await notify_new_badges(update, context, new_badges_sender)
-
-            # Notify badges for receiver (if any)
-            if new_badges_receiver:
-                badge_names = ", ".join([b.name for b in new_badges_receiver])
-                try:
-                    await context.bot.send_message(
-                        chat_id=receiver_id,
-                        text=f"🏅 ¡Has desbloqueado logros!: {badge_names}",
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"Could not notify receiver {receiver_id} of badges: {e}"
-                    )
-
         except Exception as e:
-            logger.error(f"Error processing gift {payload}: {e}")
-            await context.bot.send_message(
-                chat_id=message.chat_id,
-                text="Hubo un error entregando el regalo. Contacta con soporte.",
-            )
-            # Refund attempt
-            try:
-                await context.bot.refund_star_payment(
-                    user_id=user.id,
-                    telegram_payment_charge_id=telegram_payment_charge_id,
-                )
-            except Exception as refund_error:
-                logger.error(f"Failed to refund gift: {refund_error}")
-        return
-
-    if payload.startswith("subs_month_"):
-        try:
-            target_chat_id = int(payload.replace("subs_month_", ""))
-            chat = await services.chat_repo.load(target_chat_id)
-            if not chat:
-                chat = Chat(id=target_chat_id)
-
-            now = datetime.now(timezone.utc)
-            # If already premium and not expired, extend. Else start from now.
-            if chat.is_premium and chat.premium_until and chat.premium_until > now:
-                chat.premium_until += timedelta(days=30)
-            else:
-                chat.premium_until = now + timedelta(days=30)
-
-            await services.chat_repo.save(chat)
-
-            # Log usage for badge (El Patrón)
-            new_badges = await services.usage_service.log_usage(
-                user_id=user.id,
-                platform="telegram",
-                action=ActionType.SUBSCRIPTION,
-                metadata={"target_chat_id": target_chat_id, "amount": 100},
-            )
-
+            logger.error(f"Error sending gift image {image_path}: {e}")
             await context.bot.send_message(
                 chat_id=target_chat_id,
-                text=(
-                    "¡Pago recibido! ⭐️\n"
-                    "¡Sois VIPs! La barra libre de Cuñadismo IA está abierta por 30 días.\n"
-                    "Disfrutad de vuestros privilegios."
-                ),
+                text=caption,
+                parse_mode="HTML",
             )
 
-            # Notify badges
-            await notify_new_badges(update, context, new_badges)
+        # Check if we need to notify privately (if user is not in the group)
+        if target_chat_id != receiver_id:
+            should_notify_private = False
+            try:
+                member = await context.bot.get_chat_member(target_chat_id, receiver_id)
+                if member.status in ["left", "kicked"]:
+                    should_notify_private = True
+            except TelegramError:
+                # Likely user not in chat or chat is private/unknown to bot
+                should_notify_private = True
 
-        except Exception as e:
-            logger.error(f"Error activating subscription for {payload}: {e}")
-            await context.bot.send_message(
-                chat_id=message.chat_id,
-                text="Hubo un error activando la suscripción. Contacta con el soporte.",
+            if should_notify_private:
+                try:
+                    private_caption = (
+                        f"¡Sorpresa! 🎁\n\n"
+                        f"<b>{user.first_name}</b> te ha enviado un <b>{GIFT_NAMES[gift_type]}</b> desde el grupo.\n"
+                        f"Como no te he visto por la barra, te lo traigo aquí.\n\n"
+                        f"<i>Lo tienes guardado en tu /perfil.</i>"
+                    )
+                    with open(image_path, "rb") as photo:
+                        await context.bot.send_photo(
+                            chat_id=receiver_id,
+                            photo=photo,
+                            caption=private_caption,
+                            parse_mode="HTML",
+                        )
+                except Exception as e:
+                    logger.warning(
+                        f"Could not send private gift notification to {receiver_id}: {e}"
+                    )
+
+        # Log usage (GIFT_SENT) for sender
+        new_badges_sender = await services.usage_service.log_usage(
+            user_id=user.id,
+            platform="telegram",
+            action=ActionType.GIFT_SENT,
+            metadata={"gift_type": gift_type, "receiver_id": receiver_id},
+        )
+
+        # Log usage (GIFT_RECEIVED) for receiver
+        new_badges_receiver = await services.usage_service.log_usage(
+            user_id=receiver_id,
+            platform="telegram",
+            action=ActionType.GIFT_RECEIVED,
+            metadata={"gift_type": gift_type, "sender_id": user.id},
+        )
+
+        # Notify badges for sender
+        await notify_new_badges(update, context, new_badges_sender)
+
+        # Notify badges for receiver (if any)
+        if new_badges_receiver:
+            badge_names = ", ".join([b.name for b in new_badges_receiver])
+            try:
+                await context.bot.send_message(
+                    chat_id=receiver_id,
+                    text=f"🏅 ¡Has desbloqueado logros!: {badge_names}",
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Could not notify receiver {receiver_id} of badges: {e}"
+                )
+
+    except Exception as e:
+        logger.error(f"Error processing gift {gift_payment}: {e}")
+        await context.bot.send_message(
+            chat_id=message.chat_id,
+            text="Hubo un error entregando el regalo. Contacta con soporte.",
+        )
+        # Refund attempt
+        try:
+            await context.bot.refund_star_payment(
+                user_id=user.id,
+                telegram_payment_charge_id=charge_id,
             )
-        return
+        except Exception as refund_error:
+            logger.error(f"Failed to refund gift: {refund_error}")
+
+
+async def _fulfill_subscription(
+    update: Update,
+    context: CallbackContext,
+    message: Message,
+    subscription: SubscriptionPayment,
+    user: User,
+) -> None:
+    """Extends Suscripción Premium for the target Chat."""
+    target_chat_id = subscription.target_chat_id
+    try:
+        chat = await services.chat_repo.load(target_chat_id)
+        if not chat:
+            chat = Chat(id=target_chat_id)
+
+        now = datetime.now(timezone.utc)
+        # If already premium and not expired, extend. Else start from now.
+        if chat.is_premium and chat.premium_until and chat.premium_until > now:
+            chat.premium_until += timedelta(days=30)
+        else:
+            chat.premium_until = now + timedelta(days=30)
+
+        await services.chat_repo.save(chat)
+
+        # Log usage for badge (El Patrón)
+        new_badges = await services.usage_service.log_usage(
+            user_id=user.id,
+            platform="telegram",
+            action=ActionType.SUBSCRIPTION,
+            metadata={"target_chat_id": target_chat_id, "amount": 100},
+        )
+
+        await context.bot.send_message(
+            chat_id=target_chat_id,
+            text=(
+                "¡Pago recibido! ⭐️\n"
+                "¡Sois VIPs! La barra libre de Cuñadismo IA está abierta por 30 días.\n"
+                "Disfrutad de vuestros privilegios."
+            ),
+        )
+
+        # Notify badges
+        await notify_new_badges(update, context, new_badges)
+
+    except Exception as e:
+        logger.error(f"Error activating subscription for {target_chat_id}: {e}")
+        await context.bot.send_message(
+            chat_id=message.chat_id,
+            text="Hubo un error activando la suscripción. Contacta con el soporte.",
+        )
+
+
+async def _fulfill_poster(
+    update: Update,
+    context: CallbackContext,
+    message: Message,
+    poster: PosterPayment,
+    user: User,
+    charge_id: str,
+) -> None:
+    """Generates and delivers a Póster image from cuñadil text."""
+    payload = poster.payload
 
     # Retrieve request data
     request_data = await services.poster_request_repo.load(payload)
@@ -312,9 +346,7 @@ async def handle_successful_payment(update: Update, context: CallbackContext) ->
         await notify_new_badges(update, context, new_badges)
 
     except Exception as e:
-        logger.error(
-            f"Error delivering product for payment {telegram_payment_charge_id}: {e}"
-        )
+        logger.error(f"Error delivering product for payment {charge_id}: {e}")
         if request_data:
             request_data.status = "failed"
             await services.poster_request_repo.save(request_data)
@@ -330,7 +362,7 @@ async def handle_successful_payment(update: Update, context: CallbackContext) ->
         # Refund the stars
         try:
             await context.bot.refund_star_payment(
-                user_id=user.id, telegram_payment_charge_id=telegram_payment_charge_id
+                user_id=user.id, telegram_payment_charge_id=charge_id
             )
             await context.bot.send_message(
                 chat_id=original_chat_id,

--- a/src/tg/handlers/payments/checkout_test.py
+++ b/src/tg/handlers/payments/checkout_test.py
@@ -189,3 +189,74 @@ async def test_handle_successful_payment_failure_refund():
         )
         # Verify messages sent to stored chat_id
         assert context.bot.send_message.call_args_list[0].kwargs["chat_id"] == 999
+
+
+def _payment_update(payload: str):
+    update = MagicMock(spec=Update)
+    message = MagicMock(spec=Message)
+    update.effective_message = message
+    update.effective_user.id = 123
+    update.effective_user.name = "Pepe"
+    update.effective_user.username = "pepe"
+    message.chat.type = "private"
+    message.chat.title = "Test Chat"
+    message.chat.username = "testchat"
+    message.chat_id = 123
+
+    payment = MagicMock(spec=SuccessfulPayment)
+    payment.invoice_payload = payload
+    payment.telegram_payment_charge_id = "charge_id"
+    message.successful_payment = payment
+
+    user = MagicMock(spec=User)
+    user.id = 123
+    user.first_name = "Pepe"
+    message.from_user = user
+    return update, message
+
+
+@pytest.mark.asyncio
+async def test_handle_successful_payment_subscription_activation():
+    update, message = _payment_update("subs_month_-555")
+
+    context = MagicMock()
+    context.bot.send_message = AsyncMock()
+
+    with (
+        patch("tg.handlers.payments.checkout.services") as mock_services,
+        patch(
+            "tg.handlers.payments.checkout.notify_new_badges", new_callable=AsyncMock
+        ) as mock_notify,
+    ):
+        mock_services.chat_repo.load = AsyncMock(return_value=None)
+        mock_services.chat_repo.save = AsyncMock()
+        mock_services.usage_service.log_usage = AsyncMock(return_value=[])
+
+        await handle_successful_payment(update, context)
+
+        # A fresh Chat is created and persisted with Premium granted.
+        saved_chat = mock_services.chat_repo.save.call_args[0][0]
+        assert saved_chat.id == -555
+        assert saved_chat.is_premium is True
+        # Premium confirmation goes to the target Chat, not the payer's chat.
+        assert context.bot.send_message.call_args.kwargs["chat_id"] == -555
+        mock_notify.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_successful_payment_invalid_payload():
+    update, message = _payment_update("gift:not-a-number:200:palillo")
+
+    context = MagicMock()
+    context.bot.send_message = AsyncMock()
+
+    with patch("tg.handlers.payments.checkout.services") as mock_services:
+        mock_services.gift_repo.save = AsyncMock()
+        mock_services.chat_repo.save = AsyncMock()
+
+        await handle_successful_payment(update, context)
+
+        # Malformed payloads are rejected without delivering any product.
+        mock_services.gift_repo.save.assert_not_called()
+        mock_services.chat_repo.save.assert_not_called()
+        context.bot.send_message.assert_called_once()

--- a/src/web_test.py
+++ b/src/web_test.py
@@ -403,10 +403,16 @@ def test_web_game_page(client):
             "services.tts_service.TTSService.get_audio_url",
             return_value="http://audio.url",
         ),
+        patch(
+            "services.game_service.GameService.generate_game_token",
+            return_value="web-token",
+        ) as mock_generate_token,
     ):
         rv = client.get("/game")
         assert rv.status_code == HTTP_200_OK
         assert "PACO'S TAPAS RUNNER" in rv.text
+        assert 'const GAME_TOKEN = "web-token";' in rv.text
+        mock_generate_token.assert_called_once_with("guest")
         # Check that daily_challenge_json is rendered as an object, not empty
         assert "const DAILY_CHALLENGE = {" in rv.text
         assert '"type":' in rv.text


### PR DESCRIPTION
Implements the staged architecture roadmap in #76 (PRD: Deepen Cunhaobot domain modules). Each slice deepens a domain module behind a small, stable interface while preserving user-facing behavior and persisted-data compatibility. Code identifiers stay English; product language follows `CONTEXT.md`.

## Slices

1. **Juego / Partida** — `GameService.submit_score()` owns token validation, high-score/streak update and the single Puntuación de partida → Puntos de reputación conversion (fixes the double-award risk; US1).
2. **Pieza cuñadil intake** — `ProposalService.submit()` returns a typed `IntakeResult` (empty / duplicate approved / duplicate active / duplicate rejected / accepted). The Apelativo vs Frase cuñadil split is derived from the proposal type; the Telegram handler only translates the result.
3. **Paid fulfillment** — `services.payment.parse_payment_payload()` turns a raw invoice payload into a typed intent (`GiftPayment` / `SubscriptionPayment` / `PosterPayment`); the checkout handler routes to dedicated `_fulfill_*` helpers for Regalo, Suscripción Premium and Póster.
4. **Perfil linking** — the four duplicated content-migration loops collapse into one `_migrate_authorship()` seam, so a new authored type is a one-line extension.
5. **Logro engine** — locks the "awarded once" regression (US21); milestone rules are tested platform-neutrally (notifications remain platform adapters).
6. **Chat interaction adapters** — `ChatInteractionService` owns the shared rules (AI answer + AI_ASK Uso, smart-reaction decision, REACTION_RECEIVED Uso) consumed by both Telegram and Slack; Premium gating stays in the Telegram adapter since it varies by platform.
7. **Perfil aggregation** — `ProfileService.get_profile_summary()` returns one coherent `ProfileSummary` (Puntos, Logros, Pieza cuñadil, Regalos, Pósters) shared by the web profile and the `/perfil` bot view.
8. **Composition** — the `Container` is now the single composition root; `core.di` only exposes its singletons to Litestar, removing duplicated wiring.

Docs: `docs/domain-code-map.md` maps each deepened interface to its domain concern.

## Testing

- TDD per slice (tests first, crossing the caller-facing interface, asserting observable behavior).
- Covers the issue's Testing Decisions for intake, paid fulfillment, linking, Logro, Chat interaction and profile aggregation.

Validation:
- `uv run ty check` → All checks passed
- `uv run pytest` → 346 passed

This PR does not necessarily close #76 if further conversation sharpens later slices, but it delivers the full staged roadmap described there.
